### PR TITLE
Moves fit_results into dataset attrs instead of observations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,12 +2,18 @@
 Changelog
 =========
 
+Version 1.5
+===========
+* fit results are no longer `BenchmarkObservation`, and instead are moved into the datasets.
+
 Version 1.4
 ===========
 
 * Renames:
+
   * AnalysisResult -> BenchmarkAnalysisResult
   * RunResult -> BenchmarkRunResult
+
 * Adds BenchmarkObservation class, and modifies BenchmarkAnalysisResult so observations now accepts a list[BenchmarkObservation].
 * Adds BenchmarkObservationIdentifier class.
 * Rebases RandomizedBenchmarking benchmarks, QuantumVolume, GHZ and CLOPS to use the new Observation class.

--- a/src/iqm/benchmarks/randomized_benchmarking/clifford_rb/clifford_rb.py
+++ b/src/iqm/benchmarks/randomized_benchmarking/clifford_rb/clifford_rb.py
@@ -126,12 +126,12 @@ def clifford_rb_analysis(run: BenchmarkRunResult) -> BenchmarkAnalysisResult:
         processed_results = {
             "avg_gate_fidelity": {"value": fidelity.value, "uncertainty": fidelity.stderr},
             "decay_rate": {"value": popt["decay_rate"].value, "uncertainty": popt["decay_rate"].stderr},
-            "fit_amplitude": {"value": popt["amplitude"].value, "uncertainty": popt["amplitude"].stderr},
-            "fit_offset": {"value": popt["offset"].value, "uncertainty": popt["offset"].stderr},
         }
 
         dataset.attrs[qubits_idx].update(
             {
+                "fit_amplitude": {"value": popt["amplitude"].value, "uncertainty": popt["amplitude"].stderr},
+                "fit_offset": {"value": popt["offset"].value, "uncertainty": popt["offset"].stderr},
                 "fidelities": fidelities[str(qubits)],
                 "avg_fidelities_nominal_values": average_fidelities,
                 "avg_fidelities_stderr": stddevs_from_mean,

--- a/src/iqm/benchmarks/randomized_benchmarking/interleaved_rb/interleaved_rb.py
+++ b/src/iqm/benchmarks/randomized_benchmarking/interleaved_rb/interleaved_rb.py
@@ -168,8 +168,6 @@ def interleaved_rb_analysis(run: BenchmarkRunResult) -> BenchmarkAnalysisResult:
             processed_results[rb_type] = {
                 "avg_gate_fidelity": {"value": fidelity.value, "uncertainty": fidelity.stderr},
                 "decay_rate": {"value": popt["decay_rate"].value, "uncertainty": popt["decay_rate"].stderr},
-                "fit_amplitude": {"value": popt["amplitude"].value, "uncertainty": popt["amplitude"].stderr},
-                "fit_offset": {"value": popt["offset"].value, "uncertainty": popt["offset"].stderr},
             }
 
             observations.extend(
@@ -187,6 +185,8 @@ def interleaved_rb_analysis(run: BenchmarkRunResult) -> BenchmarkAnalysisResult:
             dataset.attrs[qubits_idx].update(
                 {
                     rb_type: {
+                        "fit_amplitude": {"value": popt["amplitude"].value, "uncertainty": popt["amplitude"].stderr},
+                        "fit_offset": {"value": popt["offset"].value, "uncertainty": popt["offset"].stderr},
                         "fidelities": fidelities[str(qubits)][rb_type],
                         "avg_fidelities_nominal_values": average_fidelities,
                         "avg_fidelities_stderr": stddevs_from_mean,

--- a/src/iqm/benchmarks/randomized_benchmarking/mirror_rb/mirror_rb.py
+++ b/src/iqm/benchmarks/randomized_benchmarking/mirror_rb/mirror_rb.py
@@ -509,12 +509,12 @@ def mrb_analysis(run: BenchmarkRunResult) -> BenchmarkAnalysisResult:
         processed_results = {
             "avg_gate_fidelity": {"value": fidelity.value, "uncertainty": fidelity.stderr},
             "decay_rate": {"value": popt["decay_rate"].value, "uncertainty": popt["decay_rate"].stderr},
-            "fit_amplitude": {"value": popt["amplitude"].value, "uncertainty": popt["amplitude"].stderr},
-            "fit_offset": {"value": popt["offset"].value, "uncertainty": popt["offset"].stderr},
         }
 
         dataset.attrs[qubits_idx].update(
             {
+                "fit_amplitude": {"value": popt["amplitude"].value, "uncertainty": popt["amplitude"].stderr},
+                "fit_offset": {"value": popt["offset"].value, "uncertainty": popt["offset"].stderr},
                 "polarizations": polarizations,
                 "avg_polarization_nominal_values": average_polarizations,
                 "avg_polatization_stderr": stddevs_from_mean,


### PR DESCRIPTION
Fit results are not considered a result per se, but a byproduct of the analysis and, like all other byproducts of the analysis, should go into the dataset. This applies to RB benchmarks