### PR TITLE
Fix observation outputs in QV & small bug in CLOPS

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+Version 1.9
+===========
+* Fixed bug (overwriting observations) in Quantum Volume.
+
 Version 1.8
 ===========
 * Changed compressive GST to operate under the new base class and added multiple qubit layouts.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 Version 1.9
 ===========
 * Fixed bug (overwriting observations) in Quantum Volume.
+* Fixed small bug in CLOPS when calling plots in simulator execution.
 
 Version 1.8
 ===========

--- a/src/iqm/benchmarks/quantum_volume/clops.py
+++ b/src/iqm/benchmarks/quantum_volume/clops.py
@@ -306,7 +306,7 @@ def clops_analysis(run: BenchmarkRunResult) -> BenchmarkAnalysisResult:
         fig_name, fig = plot_times(dataset, observations)
         plots[fig_name] = fig
     else:
-        plots["no_backend_elapsed"] = "There is no elapsed-time data associated to jobs (e.g., execution on simulator)"
+        qcvv_logger.info("There is no elapsed-time data associated to jobs (e.g., execution on simulator)")
 
     # Sort the final dataset
     dataset.attrs = dict(sorted(dataset.attrs.items()))

--- a/src/iqm/benchmarks/quantum_volume/quantum_volume.py
+++ b/src/iqm/benchmarks/quantum_volume/quantum_volume.py
@@ -339,24 +339,26 @@ def qv_analysis(run: BenchmarkRunResult) -> BenchmarkAnalysisResult:
         # Compute the HO probabilities
         qv_result = compute_heavy_output_probabilities(execution_results[str(qubits)], ideal_heavy_outputs[str(qubits)])
 
-        observations.extend([
-            BenchmarkObservation(
-                name="average_heavy_output_probability",
-                value=cumulative_hop(qv_result)[-1],
-                uncertainty=cumulative_std(qv_result)[-1],
-                identifier=BenchmarkObservationIdentifier(qubits),
-            ),
-            BenchmarkObservation(
-                name="is_succesful",
-                value=is_successful(qv_result, num_sigmas),
-                identifier=BenchmarkObservationIdentifier(qubits),
-            ),
-            BenchmarkObservation(
-                name="QV_result",
-                value=2 ** len(qubits) if is_successful(qv_result) else 1,
-                identifier=BenchmarkObservationIdentifier(qubits),
-            ),
-        ])
+        observations.extend(
+            [
+                BenchmarkObservation(
+                    name="average_heavy_output_probability",
+                    value=cumulative_hop(qv_result)[-1],
+                    uncertainty=cumulative_std(qv_result)[-1],
+                    identifier=BenchmarkObservationIdentifier(qubits),
+                ),
+                BenchmarkObservation(
+                    name="is_succesful",
+                    value=is_successful(qv_result, num_sigmas),
+                    identifier=BenchmarkObservationIdentifier(qubits),
+                ),
+                BenchmarkObservation(
+                    name="QV_result",
+                    value=2 ** len(qubits) if is_successful(qv_result) else 1,
+                    identifier=BenchmarkObservationIdentifier(qubits),
+                ),
+            ]
+        )
 
         dataset.attrs[qubits_idx].update(
             {

--- a/src/iqm/benchmarks/quantum_volume/quantum_volume.py
+++ b/src/iqm/benchmarks/quantum_volume/quantum_volume.py
@@ -339,7 +339,7 @@ def qv_analysis(run: BenchmarkRunResult) -> BenchmarkAnalysisResult:
         # Compute the HO probabilities
         qv_result = compute_heavy_output_probabilities(execution_results[str(qubits)], ideal_heavy_outputs[str(qubits)])
 
-        observations = [
+        observations.extend([
             BenchmarkObservation(
                 name="average_heavy_output_probability",
                 value=cumulative_hop(qv_result)[-1],
@@ -356,7 +356,7 @@ def qv_analysis(run: BenchmarkRunResult) -> BenchmarkAnalysisResult:
                 value=2 ** len(qubits) if is_successful(qv_result) else 1,
                 identifier=BenchmarkObservationIdentifier(qubits),
             ),
-        ]
+        ])
 
         dataset.attrs[qubits_idx].update(
             {


### PR DESCRIPTION
Current behaviour:
Observations for different qubit layouts get overwritten for vanilla QV (without REM) results, e.g., (output shown to me).
![image](https://github.com/user-attachments/assets/62470d11-3490-45b4-8537-97916179c2d4)

Correct output:
![image](https://github.com/user-attachments/assets/9658f74a-1d7c-4d87-b6c4-89b91f3207eb)
