### PR TITLE
Add classes for better handling of quantum circuits

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog
 =========
 
+Version 2.0
+===========
+* Adds `Circuits`, `BenchmarkCircuit` and `CircuitGroup` as a way to easily store and interact with multiple quantum circuits.
+* `BenchmarkRunResult` now takes a `circuits` argument, expecting an instance of `Circuits`. `QuantumCircuit` instances can now exist there instead of inside xarray Datasets. All analysis methods should also expect to use an instance of `BenchmarkRunResult`.
+* Ported all of the benchmarks subclassing from `Benchmark` to use the new containers.
+* Updates the usage of `qiskit.QuantumCircuit` to `iqm.qiskit_iqm.IQMCircuit` in many places.
+
 Version 1.12
 ===========
 * Miscellaneous small bugs fixed.
@@ -18,12 +25,6 @@ Version 1.9
 ===========
 * Fixed bug (overwriting observations) in Quantum Volume.
 * Fixed small bug in CLOPS when calling plots in simulator execution.
-Version 2.0
-===========
-* Adds `Circuits`, `BenchmarkCircuit` and `CircuitGroup` as a way to easily store and interact with multiple quantum circuits.
-* `BenchmarkRunResult` now takes a `circuits` argument, expecting an instance of `Circuits`. `QuantumCircuit` instances can now exist there instead of inside xarray Datasets. All analysis methods should also expect to use an instance of `BenchmarkRunResult`.
-* Ported all of the benchmarks subclassing from `Benchmark` to use the new containers.
-* Updates the usage of `qiskit.QuantumCircuit` to `iqm.qiskit_iqm.IQMCircuit` in many places.
 
 Version 1.8
 ===========

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,12 @@ Version 1.9
 ===========
 * Fixed bug (overwriting observations) in Quantum Volume.
 * Fixed small bug in CLOPS when calling plots in simulator execution.
+Version 2.0
+===========
+* Adds `Circuits`, `BenchmarkCircuit` and `CircuitGroup` as a way to easily store and interact with multiple quantum circuits.
+* `BenchmarkRunResult` now takes a `circuits` argument, expecting an instance of `Circuits`. `QuantumCircuit` instances can now exist there instead of inside xarray Datasets. All analysis methods should also expect to use an instance of `BenchmarkRunResult`.
+* Ported all of the benchmarks subclassing from `Benchmark` to use the new containers.
+* Updates the usage of `qiskit.QuantumCircuit` to `iqm.qiskit_iqm.IQMCircuit` in many places.
 
 Version 1.8
 ===========

--- a/src/iqm/benchmarks/__init__.py
+++ b/src/iqm/benchmarks/__init__.py
@@ -25,6 +25,7 @@ from .benchmark_definition import (
     BenchmarkObservationIdentifier,
     BenchmarkRunResult,
 )
+from .circuit_containers import BenchmarkCircuit, CircuitGroup, Circuits
 from .entanglement.ghz import GHZBenchmark, GHZConfiguration
 from .quantum_volume.clops import CLOPSBenchmark, CLOPSConfiguration
 from .quantum_volume.quantum_volume import QuantumVolumeBenchmark, QuantumVolumeConfiguration

--- a/src/iqm/benchmarks/benchmark_definition.py
+++ b/src/iqm/benchmarks/benchmark_definition.py
@@ -21,7 +21,7 @@ import copy
 from copy import deepcopy
 from dataclasses import dataclass, field
 import functools
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 import uuid
 
 from matplotlib.figure import Figure
@@ -124,10 +124,10 @@ class BenchmarkAnalysisResult:
         Args:
             run: A run for which analysis result is created.
         """
-        return cls(dataset=run.dataset)
+        return cls(dataset=run.dataset, circuits=run.circuits)
 
 
-def default_analysis_function(result: BenchmarkAnalysisResult) -> BenchmarkAnalysisResult:
+def default_analysis_function(result: BenchmarkRunResult) -> BenchmarkAnalysisResult:
     """
     The default analysis that only pass the result through.
     """
@@ -210,10 +210,9 @@ class Benchmark(ABC):
     accept ``AnalysisResult`` as its input and return the final result.
     """
 
-    analysis_function = staticmethod(default_analysis_function)
+    analysis_function: Callable[BenchmarkRunResult, BenchmarkAnalysisResult] = staticmethod(default_analysis_function)
     default_options: dict[str, Any] | None = None
     options: dict[str, Any] | None = None
-    # name: str = "unnamed_benchmark"
 
     def __init__(self, backend: Union[str, IQMBackendBase], configuration: BenchmarkConfigurationBase, **kwargs):
 
@@ -303,6 +302,5 @@ class Benchmark(ABC):
             the ``analysis_function`` field.
         """
         run = self.runs[run_index]
-        # result = BenchmarkAnalysisResult.from_run_result(run)
         updated_result = self.analysis_function(run)
         return updated_result

--- a/src/iqm/benchmarks/benchmark_definition.py
+++ b/src/iqm/benchmarks/benchmark_definition.py
@@ -96,6 +96,7 @@ class BenchmarkAnalysisResult:
     """
 
     dataset: xr.Dataset
+    circuits: Optional[Circuits] = field(default=None)
     plots: dict[str, Figure] = field(default_factory=lambda: ({}))
     observations: list[BenchmarkObservation] = field(default_factory=lambda: [])
 
@@ -124,14 +125,14 @@ class BenchmarkAnalysisResult:
         Args:
             run: A run for which analysis result is created.
         """
-        return cls(dataset=run.dataset)
+        return cls(dataset=run.dataset, circuits=Circuits)
 
 
 def default_analysis_function(result: BenchmarkRunResult) -> BenchmarkAnalysisResult:
     """
     The default analysis that only pass the result through.
     """
-    return result
+    return BenchmarkAnalysisResult.from_run_result(result)
 
 
 def merge_datasets_dac(datasets: List[xr.Dataset]) -> xr.Dataset:
@@ -210,7 +211,7 @@ class Benchmark(ABC):
     accept ``AnalysisResult`` as its input and return the final result.
     """
 
-    analysis_function: Callable[BenchmarkRunResult, BenchmarkAnalysisResult] = staticmethod(default_analysis_function)
+    analysis_function: Callable[[BenchmarkRunResult], BenchmarkAnalysisResult] = staticmethod(default_analysis_function)
     default_options: dict[str, Any] | None = None
     options: dict[str, Any] | None = None
 

--- a/src/iqm/benchmarks/benchmark_definition.py
+++ b/src/iqm/benchmarks/benchmark_definition.py
@@ -29,7 +29,7 @@ import matplotlib.pyplot as plt
 import xarray as xr
 
 from iqm.benchmarks.benchmark import BenchmarkConfigurationBase
-from iqm.benchmarks.circuit_containers import Circuits
+from iqm.benchmarks.circuit_containers import BenchmarkCircuit, Circuits
 from iqm.benchmarks.utils import get_iqm_backend, timeit
 from iqm.qiskit_iqm.iqm_backend import IQMBackendBase
 from iqm.qiskit_iqm.iqm_provider import IQMBackend, IQMFacadeBackend
@@ -237,8 +237,8 @@ class Benchmark(ABC):
         self.routing_method = self.configuration.routing_method
         self.physical_layout = self.configuration.physical_layout
 
-        self.transpiled_circuits = {}
-        self.untranspiled_circuits = {}
+        self.transpiled_circuits: BenchmarkCircuit
+        self.untranspiled_circuits: BenchmarkCircuit
 
         # From exa_support MR
         self.options = copy.copy(self.default_options) if self.default_options else {}

--- a/src/iqm/benchmarks/benchmark_definition.py
+++ b/src/iqm/benchmarks/benchmark_definition.py
@@ -35,17 +35,6 @@ from iqm.qiskit_iqm.iqm_backend import IQMBackendBase
 from iqm.qiskit_iqm.iqm_provider import IQMBackend, IQMFacadeBackend
 
 
-# THINGS TO FIGURE OUT! What is the generic case here?
-# For example, thinking about Parallel 2QBRB,
-# is the first key an identifier for the circuit and the second one an identifier for the qubits?
-# Since we are not using python 3.12+, we need to use TypeAlias instead of the type declaration
-
-# CircuitIdentifier: TypeAlias = str
-# QuantumRegisterIdentifier: TypeAlias = str
-# BenchmarkCircuit: TypeAlias = Dict[CircuitIdentifier, Dict[QuantumRegisterIdentifier, IQMCircuit]]
-
-
-
 @dataclass
 class BenchmarkObservationIdentifier:
     """Identifier for observations for ease of use
@@ -165,7 +154,6 @@ def merge_datasets_dac(datasets: List[xr.Dataset]) -> xr.Dataset:
     return merge_datasets_dac(datasets_new)
 
 
-# TODO: Change the way of storage to the one developed in Pulla adapter
 @timeit
 def add_counts_to_dataset(counts: List[Dict[str, int]], identifier: str, dataset: xr.Dataset):
     """Adds the counts from a cortex job result to the given dataset.

--- a/src/iqm/benchmarks/benchmark_definition.py
+++ b/src/iqm/benchmarks/benchmark_definition.py
@@ -236,6 +236,9 @@ class Benchmark(ABC):
         self.routing_method = self.configuration.routing_method
         self.physical_layout = self.configuration.physical_layout
 
+        self.transpiled_circuits = {}
+        self.untranspiled_circuits = {}
+
         # From exa_support MR
         self.options = copy.copy(self.default_options) if self.default_options else {}
         self.options.update(kwargs)

--- a/src/iqm/benchmarks/benchmark_definition.py
+++ b/src/iqm/benchmarks/benchmark_definition.py
@@ -241,16 +241,6 @@ class Benchmark(ABC):
         self.options.update(kwargs)
         self.runs: list[BenchmarkRunResult] = []
 
-    # @property
-    # @abstractmethod
-    # def untranspiled_circuits(self) -> BenchmarkCircuit:
-    #     pass
-    #
-    # @property
-    # @abstractmethod
-    # def transpiled_circuits(self) -> BenchmarkCircuit:
-    #     pass
-
     @classmethod
     @abstractmethod
     def name(cls):

--- a/src/iqm/benchmarks/benchmark_definition.py
+++ b/src/iqm/benchmarks/benchmark_definition.py
@@ -150,7 +150,7 @@ def merge_datasets_dac(datasets: List[xr.Dataset]) -> xr.Dataset:
         if i == (len(datasets) - 1):
             datasets_new.append(datasets[i])
         else:
-            datasets_new.append(xr.merge(datasets[i: i + 2]))
+            datasets_new.append(xr.merge(datasets[i : i + 2]))
     return merge_datasets_dac(datasets_new)
 
 

--- a/src/iqm/benchmarks/benchmark_definition.py
+++ b/src/iqm/benchmarks/benchmark_definition.py
@@ -124,7 +124,7 @@ class BenchmarkAnalysisResult:
         Args:
             run: A run for which analysis result is created.
         """
-        return cls(dataset=run.dataset, circuits=run.circuits)
+        return cls(dataset=run.dataset)
 
 
 def default_analysis_function(result: BenchmarkRunResult) -> BenchmarkAnalysisResult:

--- a/src/iqm/benchmarks/benchmark_definition.py
+++ b/src/iqm/benchmarks/benchmark_definition.py
@@ -82,6 +82,7 @@ class BenchmarkRunResult:
     """
 
     dataset: xr.Dataset
+    circuits: Circuits
 
 
 @dataclass
@@ -281,7 +282,7 @@ class Benchmark(ABC):
             self.backend.run, calibration_set_id=calibration_set_id
         )  # type: ignore
         dataset = self.execute(backend_for_execute)
-        run = BenchmarkRunResult(dataset)
+        run = BenchmarkRunResult(dataset, self.circuits)
         self.runs.append(run)
         return run
 
@@ -302,6 +303,6 @@ class Benchmark(ABC):
             the ``analysis_function`` field.
         """
         run = self.runs[run_index]
-        result = BenchmarkAnalysisResult.from_run_result(run)
-        updated_result = self.analysis_function(result)
+        # result = BenchmarkAnalysisResult.from_run_result(run)
+        updated_result = self.analysis_function(run)
         return updated_result

--- a/src/iqm/benchmarks/circuit_containers.py
+++ b/src/iqm/benchmarks/circuit_containers.py
@@ -16,13 +16,10 @@
 This module contains classes to easily interact with quantum circuits
 """
 
-import copy
 from dataclasses import dataclass, field
 from typing import List, Optional, TypeAlias
-import warnings
 
 from qiskit.circuit import Qubit
-from qiskit.circuit.quantumregister import QuantumRegister
 
 from iqm.qiskit_iqm.iqm_circuit import IQMCircuit
 
@@ -52,6 +49,10 @@ class CircuitGroup:
             qubit_set.add(*circuit.qubits)
         return qubit_set
 
+    def __setitem__(self, key: str, value: IQMCircuit) -> None:
+        value.name = key
+        return self.add_circuit(value)
+
     def add_circuit(self, circuit: IQMCircuit):
         self.circuits.append(circuit)
 
@@ -77,6 +78,14 @@ class BenchmarkCircuit:
         benchmark_circuit_names = filter(lambda x: x.name == name, self.circuit_groups)
         next_value = next(benchmark_circuit_names, None)
         return next_value
+
+    @property
+    def groups(self) -> List[CircuitGroup]:
+        return self.circuit_groups
+
+    @property
+    def group_names(self) -> List[str]:
+        return list(map(lambda x: x.name, self.circuit_groups))
 
     @property
     def qubit_indices(self) -> set[int]:
@@ -107,6 +116,10 @@ class BenchmarkCircuit:
             layout_set.add(*circuit.qubit_layouts)
         return layout_set
 
+    def __setitem__(self, key: str, value: CircuitGroup) -> None:
+        value.name = key
+        return self.circuit_groups.append(value)
+
     def __getitem__(self, key: str) -> List[CircuitGroup]:
         return self.get_circuit_group_by_name(key)
 
@@ -114,6 +127,10 @@ class BenchmarkCircuit:
 @dataclass
 class Circuits:
     benchmark_circuits: List[BenchmarkCircuit] = field(default_factory=list)
+
+    def __setitem__(self, key: str, value: BenchmarkCircuit) -> None:
+        value.name = key
+        return self.benchmark_circuits.append(value)
 
     def __getitem__(self, key: str) -> List[BenchmarkCircuit]:
         return self.get_benchmark_circuits_by_name(key)

--- a/src/iqm/benchmarks/circuit_containers.py
+++ b/src/iqm/benchmarks/circuit_containers.py
@@ -24,26 +24,50 @@ from qiskit.circuit import Qubit
 from iqm.qiskit_iqm.iqm_circuit import IQMCircuit
 
 
-QubitLayout: TypeAlias = tuple[tuple[Qubit]]
+QubitLayout: TypeAlias = tuple[Qubit]
+QubitLayouts: TypeAlias = tuple[QubitLayout]
 QubitLayoutIndices: TypeAlias = tuple[tuple[int]]
 
 
+# pylint: disable=protected-access
 @dataclass
 class CircuitGroup:
+    """Group of `IQMCircuits`. It represents a list of circuits with a common purpose, typically executed in a batch.
+
+    Attributes:
+        circuits: List of `IQMCircuit`.
+        name: Name of the group.
+    """
+
     circuits: List[IQMCircuit] = field(default_factory=list)
     name: Optional[str] = field(default="")
 
     @property
     def qubit_layouts_by_index(self) -> QubitLayoutIndices:
+        """The qubit layouts contained in all the circuits, where the qubits are represented by an integer.
+
+        Returns:
+            All qubit layouts.
+        """
         return tuple(tuple(qubit._index for qubit in layout) for layout in self.qubit_layouts)
 
     @property
-    def qubit_layouts(self, by_index: bool = True) -> QubitLayout:
+    def qubit_layouts(self) -> QubitLayouts:
+        """The qubit layouts contained in all the circuits, where the qubits are represented by an instance of `Qubit`.
+
+        Returns:
+            All qubit layouts.
+        """
         qubit_layouts = tuple(map(lambda x: tuple(x._data.active_bits()[0]), self.circuits))
         return qubit_layouts
 
     @property
-    def qubits(self) -> set[int]:
+    def qubits(self) -> set[Qubit]:
+        """The set of active qubits in all of the circuits
+
+        Returns:
+            A set of `Qubit`
+        """
         qubit_set = set()
         for circuit in self.circuits:
             for qubit in circuit._data.active_bits()[0]:
@@ -55,14 +79,32 @@ class CircuitGroup:
         return self.add_circuit(value)
 
     def add_circuit(self, circuit: IQMCircuit):
+        """Adds a circuit to the internal list
+
+        Args:
+            circuit: Circuit to add.
+        """
         self.circuits.append(circuit)
 
     @property
     def circuit_names(self) -> list[str]:
+        """Name of all the circuits contained in the group as a string
+
+        Returns:
+            List of strings
+        """
         benchmark_circuit_names = list(map(lambda x: x.name, self.circuits))
         return benchmark_circuit_names
 
-    def get_circuits_by_name(self, name: str) -> List[IQMCircuit]:
+    def get_circuits_by_name(self, name: str) -> Optional[IQMCircuit]:
+        """Returns a list of the internal circuits that share the same name
+
+        Args:
+            name: Name of the circuit to return as a string
+
+        Returns:
+            The circuit with the desired name as a string, or None if they are not found.
+        """
         benchmark_circuit_names = filter(lambda x: x.name == name, self.circuits)
         return next(benchmark_circuit_names, None)
 
@@ -72,24 +114,45 @@ class CircuitGroup:
 
 @dataclass
 class BenchmarkCircuit:
+    """A class grouping a list of `CircuitGroup` into a single purpose. This can typically represent, for example,
+    all of the transpiled circuits that are executed.
+
+    Attributes:
+        name: Name of the `BenchmarkCircuit`.
+        circuit_groups: List of `CircuitGroup` contained inside
+
+    """
+
     name: str
     circuit_groups: List[CircuitGroup] = field(default_factory=list)
 
-    def get_circuit_group_by_name(self, name: str) -> CircuitGroup:
+    def get_circuit_group_by_name(self, name: str) -> Optional[CircuitGroup]:
+        """Gets a `CircuitGroup` by name.
+
+        Args:
+            name: name of the group.
+
+        Returns:
+            The desired `CircuitGroup`, or None if it does not exist.
+
+        """
         benchmark_circuit_names = filter(lambda x: x.name == name, self.circuit_groups)
         next_value = next(benchmark_circuit_names, None)
         return next_value
 
     @property
     def groups(self) -> List[CircuitGroup]:
+        """The circuit groups inside."""
         return self.circuit_groups
 
     @property
     def group_names(self) -> List[str]:
+        """Names of all the contained `CircuitGroup`."""
         return list(map(lambda x: x.name, self.circuit_groups))
 
     @property
     def qubit_indices(self) -> set[int]:
+        """Set of all the qubits used in all the `CircuitGroup`, represented as an integer."""
         qubit_set = set()
         for circuit in self.circuit_groups:
             for qubit_index in map(lambda x: x._index, circuit.qubits):
@@ -98,6 +161,7 @@ class BenchmarkCircuit:
 
     @property
     def qubits(self) -> set[Qubit]:
+        """Set of all the qubits used in all the `CircuitGroup`, represented as an instance of `Qubit`."""
         qubit_set = set()
         for qubit in map(lambda x: x.qubits, self.circuit_groups):
             qubit_set = qubit_set.union(qubit)
@@ -105,13 +169,15 @@ class BenchmarkCircuit:
 
     @property
     def qubit_layouts_by_index(self) -> set[QubitLayoutIndices]:
+        """Set of all the qubit layouts used, where the qubits are represented as an integer."""
         layout_set = set()
         for layout in map(lambda x: x.qubit_layouts_by_index, self.circuit_groups):
             layout_set.add(layout)
         return layout_set
 
     @property
-    def qubit_layouts(self) -> set[QubitLayout]:
+    def qubit_layouts(self) -> set[QubitLayouts]:
+        """Set of all the qubit layouts used, where the qubits are represented as an instance of `Qubit`."""
         layout_set = set()
         for layout in map(lambda x: x.qubit_layouts, self.circuit_groups):
             layout_set.add(layout)
@@ -127,6 +193,12 @@ class BenchmarkCircuit:
 
 @dataclass
 class Circuits:
+    """Container for all the `BenchmarkCircuit` that are generated in a single benchmark execution.
+
+    Attributes:
+        benchmark_circuits: List of `BenchmarkCircuit` contained.
+    """
+
     benchmark_circuits: List[BenchmarkCircuit] = field(default_factory=list)
 
     def __setitem__(self, key: str, value: BenchmarkCircuit) -> None:
@@ -136,6 +208,14 @@ class Circuits:
     def __getitem__(self, key: str) -> List[BenchmarkCircuit]:
         return self.get_benchmark_circuits_by_name(key)
 
-    def get_benchmark_circuits_by_name(self, name: str) -> List[BenchmarkCircuit]:
+    def get_benchmark_circuits_by_name(self, name: str) -> Optional[BenchmarkCircuit]:
+        """Returned the `BenchmarkCircuit` by name.
+
+        Args:
+            name: Name of the requested `BenchmarkCircuit` as a string
+
+        Returns:
+            The requested `BenchmarkCircuit` if it exists, None otherwise
+        """
         benchmark_circuit_names = filter(lambda x: x.name == name, self.benchmark_circuits)
         return next(benchmark_circuit_names, None)

--- a/src/iqm/benchmarks/circuit_containers.py
+++ b/src/iqm/benchmarks/circuit_containers.py
@@ -46,7 +46,8 @@ class CircuitGroup:
     def qubits(self) -> set[int]:
         qubit_set = set()
         for circuit in self.circuits:
-            qubit_set.add(*circuit.qubits)
+            for qubit in circuit.qubits:
+                qubit_set.add(qubit)
         return qubit_set
 
     def __setitem__(self, key: str, value: IQMCircuit) -> None:
@@ -98,22 +99,22 @@ class BenchmarkCircuit:
     @property
     def qubits(self) -> set[Qubit]:
         qubit_set = set()
-        for circuit in self.circuit_groups:
-            qubit_set.add(*circuit.qubits)
+        for qubit in map(lambda x: x.qubits, self.circuit_groups):
+            qubit_set = qubit_set.union(qubit)
         return qubit_set
 
     @property
     def qubit_layouts_by_index(self) -> set[QubitLayoutIndices]:
         layout_set = set()
-        for circuit in self.circuit_groups:
-            layout_set.add(*circuit.qubit_layouts_by_index)
+        for layout in map(lambda x: x.qubit_layouts_by_index, self.circuit_groups):
+            layout_set.add(layout)
         return layout_set
 
     @property
     def qubit_layouts(self) -> set[QubitLayout]:
         layout_set = set()
-        for circuit in self.circuit_groups:
-            layout_set.add(*circuit.qubit_layouts)
+        for layout in map(lambda x: x.qubit_layouts, self.circuit_groups):
+            layout_set.add(layout)
         return layout_set
 
     def __setitem__(self, key: str, value: CircuitGroup) -> None:

--- a/src/iqm/benchmarks/circuit_containers.py
+++ b/src/iqm/benchmarks/circuit_containers.py
@@ -1,0 +1,123 @@
+# Copyright 2024 IQM Benchmarks developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module contains classes to easily interact with quantum circuits
+"""
+
+import copy
+from dataclasses import dataclass, field
+from typing import List, Optional, TypeAlias
+import warnings
+
+from qiskit.circuit import Qubit
+from qiskit.circuit.quantumregister import QuantumRegister
+
+from iqm.qiskit_iqm.iqm_circuit import IQMCircuit
+
+
+QubitLayout: TypeAlias = tuple[tuple[Qubit]]
+QubitLayoutIndices: TypeAlias = tuple[tuple[int]]
+
+
+@dataclass
+class CircuitGroup:
+    circuits: List[IQMCircuit] = field(default_factory=list)
+    name: Optional[str] = field(default="")
+
+    @property
+    def qubit_layouts_by_index(self) -> QubitLayoutIndices:
+        return tuple(map(lambda x: tuple(q._index for q in x.qubits), self.circuits))
+
+    @property
+    def qubit_layouts(self, by_index: bool = True) -> QubitLayout:
+        qubit_layouts = tuple(map(lambda x: tuple(x.qubits), self.circuits))
+        return qubit_layouts
+
+    @property
+    def qubits(self) -> set[int]:
+        qubit_set = set()
+        for circuit in self.circuits:
+            qubit_set.add(*circuit.qubits)
+        return qubit_set
+
+    def add_circuit(self, circuit: IQMCircuit):
+        self.circuits.append(circuit)
+
+    @property
+    def circuit_names(self) -> list[str]:
+        benchmark_circuit_names = list(map(lambda x: x.name, self.circuits))
+        return benchmark_circuit_names
+
+    def get_circuits_by_name(self, name: str) -> List[IQMCircuit]:
+        benchmark_circuit_names = filter(lambda x: x.name == name, self.circuits)
+        return next(benchmark_circuit_names, None)
+
+    def __getitem__(self, key: str) -> IQMCircuit:
+        return self.get_circuits_by_name(key)
+
+
+@dataclass
+class BenchmarkCircuit:
+    name: str
+    circuit_groups: List[CircuitGroup] = field(default_factory=list)
+
+    def get_circuit_group_by_name(self, name: str) -> CircuitGroup:
+        benchmark_circuit_names = filter(lambda x: x.name == name, self.circuit_groups)
+        next_value = next(benchmark_circuit_names, None)
+        return next_value
+
+    @property
+    def qubit_indices(self) -> set[int]:
+        qubit_set = set()
+        for circuit in self.circuit_groups:
+            for qubit_index in map(lambda x: x._index, circuit.qubits):
+                qubit_set.add(qubit_index)
+        return qubit_set
+
+    @property
+    def qubits(self) -> set[Qubit]:
+        qubit_set = set()
+        for circuit in self.circuit_groups:
+            qubit_set.add(*circuit.qubits)
+        return qubit_set
+
+    @property
+    def qubit_layouts_by_index(self) -> set[QubitLayoutIndices]:
+        layout_set = set()
+        for circuit in self.circuit_groups:
+            layout_set.add(*circuit.qubit_layouts_by_index)
+        return layout_set
+
+    @property
+    def qubit_layouts(self) -> set[QubitLayout]:
+        layout_set = set()
+        for circuit in self.circuit_groups:
+            layout_set.add(*circuit.qubit_layouts)
+        return layout_set
+
+    def __getitem__(self, key: str) -> List[CircuitGroup]:
+        return self.get_circuit_group_by_name(key)
+
+
+@dataclass
+class Circuits:
+    benchmark_circuits: List[BenchmarkCircuit] = field(default_factory=list)
+
+    def __getitem__(self, key: str) -> List[BenchmarkCircuit]:
+        return self.get_benchmark_circuits_by_name(key)
+
+    def get_benchmark_circuits_by_name(self, name: str) -> List[BenchmarkCircuit]:
+        benchmark_circuit_names = filter(lambda x: x.name == name, self.benchmark_circuits)
+        return next(benchmark_circuit_names, None)

--- a/src/iqm/benchmarks/circuit_containers.py
+++ b/src/iqm/benchmarks/circuit_containers.py
@@ -35,18 +35,18 @@ class CircuitGroup:
 
     @property
     def qubit_layouts_by_index(self) -> QubitLayoutIndices:
-        return tuple(map(lambda x: tuple(q._index for q in x.qubits), self.circuits))
+        return tuple(tuple(qubit._index for qubit in layout) for layout in self.qubit_layouts)
 
     @property
     def qubit_layouts(self, by_index: bool = True) -> QubitLayout:
-        qubit_layouts = tuple(map(lambda x: tuple(x.qubits), self.circuits))
+        qubit_layouts = tuple(map(lambda x: tuple(x._data.active_bits()[0]), self.circuits))
         return qubit_layouts
 
     @property
     def qubits(self) -> set[int]:
         qubit_set = set()
         for circuit in self.circuits:
-            for qubit in circuit.qubits:
+            for qubit in circuit._data.active_bits()[0]:
                 qubit_set.add(qubit)
         return qubit_set
 

--- a/src/iqm/benchmarks/circuit_containers.py
+++ b/src/iqm/benchmarks/circuit_containers.py
@@ -24,9 +24,9 @@ from qiskit.circuit import Qubit
 from iqm.qiskit_iqm.iqm_circuit import IQMCircuit
 
 
-QubitLayout: TypeAlias = tuple[Qubit]
-QubitLayouts: TypeAlias = tuple[QubitLayout]
-QubitLayoutIndices: TypeAlias = tuple[tuple[int]]
+QubitLayout: TypeAlias = tuple[Qubit, ...]
+QubitLayouts: TypeAlias = tuple[QubitLayout, ...]
+QubitLayoutIndices: TypeAlias = tuple[tuple[int, ...], ...]
 
 
 # pylint: disable=protected-access
@@ -49,7 +49,7 @@ class CircuitGroup:
         Returns:
             All qubit layouts.
         """
-        return tuple(tuple(qubit._index for qubit in layout) for layout in self.qubit_layouts)
+        return tuple(tuple(int(qubit._index) for qubit in layout) for layout in self.qubit_layouts)
 
     @property
     def qubit_layouts(self) -> QubitLayouts:
@@ -108,7 +108,7 @@ class CircuitGroup:
         benchmark_circuit_names = filter(lambda x: x.name == name, self.circuits)
         return next(benchmark_circuit_names, None)
 
-    def __getitem__(self, key: str) -> IQMCircuit:
+    def __getitem__(self, key: str) -> Optional[IQMCircuit]:
         return self.get_circuits_by_name(key)
 
 
@@ -146,9 +146,9 @@ class BenchmarkCircuit:
         return self.circuit_groups
 
     @property
-    def group_names(self) -> List[str]:
+    def group_names(self) -> List[str | None]:
         """Names of all the contained `CircuitGroup`."""
-        return list(map(lambda x: x.name, self.circuit_groups))
+        return list(map(lambda x: x.name, self.circuit_groups)) if len(self.circuit_groups) > 0 else []
 
     @property
     def qubit_indices(self) -> set[int]:
@@ -162,7 +162,7 @@ class BenchmarkCircuit:
     @property
     def qubits(self) -> set[Qubit]:
         """Set of all the qubits used in all the `CircuitGroup`, represented as an instance of `Qubit`."""
-        qubit_set = set()
+        qubit_set: set[Qubit] = set()
         for qubit in map(lambda x: x.qubits, self.circuit_groups):
             qubit_set = qubit_set.union(qubit)
         return qubit_set
@@ -187,7 +187,7 @@ class BenchmarkCircuit:
         value.name = key
         return self.circuit_groups.append(value)
 
-    def __getitem__(self, key: str) -> List[CircuitGroup]:
+    def __getitem__(self, key: str) -> CircuitGroup | None:
         return self.get_circuit_group_by_name(key)
 
 
@@ -205,7 +205,7 @@ class Circuits:
         value.name = key
         return self.benchmark_circuits.append(value)
 
-    def __getitem__(self, key: str) -> List[BenchmarkCircuit]:
+    def __getitem__(self, key: str) -> BenchmarkCircuit | None:
         return self.get_benchmark_circuits_by_name(key)
 
     def get_benchmark_circuits_by_name(self, name: str) -> Optional[BenchmarkCircuit]:

--- a/src/iqm/benchmarks/compressive_gst/compressive_gst.py
+++ b/src/iqm/benchmarks/compressive_gst/compressive_gst.py
@@ -30,7 +30,6 @@ The full benchmark executes the following steps:
 from typing import Any, Dict, List, Tuple, Type, Union
 
 import numpy as np
-from qiskit import QuantumCircuit
 from qiskit.circuit.library import CZGate, RGate
 import xarray as xr
 
@@ -46,6 +45,7 @@ from iqm.benchmarks.utils import (
     submit_execute,
     timeit,
 )
+from iqm.qiskit_iqm import IQMCircuit as QuantumCircuit
 from iqm.qiskit_iqm.iqm_backend import IQMBackendBase
 from mGST import additional_fns, qiskit_interface
 from mGST.qiskit_interface import add_idle_gates, remove_idle_wires
@@ -161,8 +161,6 @@ class CompressiveGST(Benchmark):
             self.untranspiled_circuits.circuit_groups.append(
                 CircuitGroup(name=str(qubits), circuits=transpiled_qc_list)
             )
-            # self.untranspiled_circuits.update({str(qubits): raw_qc_list})
-            # self.transpiled_circuits.update({str(qubits): transpiled_qc_list})
 
     def add_configuration_to_dataset(self, dataset):  # CHECK
         """

--- a/src/iqm/benchmarks/compressive_gst/compressive_gst.py
+++ b/src/iqm/benchmarks/compressive_gst/compressive_gst.py
@@ -157,17 +157,9 @@ class CompressiveGST(Benchmark):
                 drop_final_rz=False,
             )
             # Saving raw and transpiled circuits in a consistent format with other benchmarks
-            self.transpiled_circuits.circuit_groups.append(
-                CircuitGroup(
-                    name=str(qubits),
-                    circuits=raw_qc_list
-                )
-            )
+            self.transpiled_circuits.circuit_groups.append(CircuitGroup(name=str(qubits), circuits=raw_qc_list))
             self.untranspiled_circuits.circuit_groups.append(
-                CircuitGroup(
-                    name=str(qubits),
-                    circuits=transpiled_qc_list
-                )
+                CircuitGroup(name=str(qubits), circuits=transpiled_qc_list)
             )
             # self.untranspiled_circuits.update({str(qubits): raw_qc_list})
             # self.transpiled_circuits.update({str(qubits): transpiled_qc_list})

--- a/src/iqm/benchmarks/entanglement/ghz.py
+++ b/src/iqm/benchmarks/entanglement/ghz.py
@@ -439,8 +439,8 @@ def extract_fidelities(cal_url: str, qubit_layout: List[int]) -> Tuple[List[List
             idx_1 = key.index(".QB")
             idx_2 = key.index("__QB")
             idx_3 = key.index(".fidelity")
-            qb1 = int(key[idx_1 + 3: idx_2]) - 1
-            qb2 = int(key[idx_2 + 4: idx_3]) - 1
+            qb1 = int(key[idx_1 + 3 : idx_2]) - 1
+            qb2 = int(key[idx_2 + 4 : idx_3]) - 1
             if all([qb1 in qubit_layout, qb2 in qubit_layout]):
                 list_couplings.append([qubit_mapping[qb1], qubit_mapping[qb2]])
                 list_fids.append(float(res["metrics"][key]["value"]))
@@ -700,9 +700,7 @@ class GHZBenchmark(Benchmark):
                 final_ghz = ghz_native_transpiled[index_min_depth]
                 circuit_group.add_circuit([ghz_log[index_min_depth]])
         self.circuits['untranspiled_circuits'].circuit_groups.append(circuit_group)
-        return CircuitGroup(
-            name=f"{qubit_layout}_native_ghz",
-            circuits=[final_ghz[0]])
+        return CircuitGroup(name=f"{qubit_layout}_native_ghz", circuits=[final_ghz[0]])
 
     def generate_coherence_meas_circuits(self, qubit_layout: List[int], qubit_count: int) -> List[QuantumCircuit]:
         """
@@ -767,14 +765,16 @@ class GHZBenchmark(Benchmark):
         # Generate the list of circuits
         idx = BenchmarkObservationIdentifier(qubit_layout).string_identifier
 
-        
         qcvv_logger.info(f"Now generating a {len(qubit_layout)}-qubit GHZ state on qubits {qubit_layout}")
         transpiled_ghz_group: CircuitGroup = self.generate_native_ghz(
-            qubit_layout, qubit_count, self.state_generation_routine)
+            qubit_layout, qubit_count, self.state_generation_routine
+        )
 
         match self.fidelity_routine:
             case "randomized_measurements":
-                all_circuits_list, _ = append_rms(transpiled_ghz_group.circuits[0], cast(int, self.num_RMs), self.backend)
+                all_circuits_list, _ = append_rms(
+                    transpiled_ghz_group.circuits[0], cast(int, self.num_RMs), self.backend
+                )
                 transpiled_ghz_group.circuits = all_circuits_list
             case "coherences":
                 all_circuits_list = self.generate_coherence_meas_circuits(qubit_layout, qubit_count)

--- a/src/iqm/benchmarks/entanglement/ghz.py
+++ b/src/iqm/benchmarks/entanglement/ghz.py
@@ -654,8 +654,6 @@ class GHZBenchmark(Benchmark):
         if routine == "naive":
             ghz: QuantumCircuit = generate_ghz_linear(qubit_count)
             circuit_group.add_circuit(ghz)
-            # self.untranspiled_circuits.circuit_group.append([ghz])
-            # self.untranspiled_circuits[idx].update({qubit_count: ghz})
             ghz_native_transpiled, _ = perform_backend_transpilation(
                 [ghz],
                 self.backend,
@@ -673,7 +671,6 @@ class GHZBenchmark(Benchmark):
                 graph = get_edges(self.backend.coupling_map, qubit_layout)
             ghz, _ = generate_ghz_spanning_tree(graph, qubit_layout, qubit_count)
             circuit_group.add_circuit(ghz)
-            # self.untranspiled_circuits[idx].update({qubit_count: ghz})
             ghz_native_transpiled, _ = perform_backend_transpilation(
                 [ghz],
                 self.backend,
@@ -698,12 +695,10 @@ class GHZBenchmark(Benchmark):
                 index_min_2q = np.argmin([c.count_ops()["cz"] for c in ghz_native_transpiled])
                 final_ghz = ghz_native_transpiled[index_min_2q]
                 circuit_group.add_circuit(ghz_log[index_min_2q])
-                # self.untranspiled_circuits[idx].update({qubit_count: ghz_log[index_min_2q]})
             else:
                 index_min_depth = np.argmin([c.depth() for c in ghz_native_transpiled])
                 final_ghz = ghz_native_transpiled[index_min_depth]
                 circuit_group.add_circuit([ghz_log[index_min_depth]])
-                # self.untranspiled_circuits[idx].update({qubit_count: ghz_log[index_min_depth]})
         self.circuits['untranspiled_circuits'].circuit_groups.append(circuit_group)
         return CircuitGroup(
             name=f"{qubit_layout}_native_ghz",
@@ -752,7 +747,6 @@ class GHZBenchmark(Benchmark):
         )
         circuit_group = CircuitGroup(name=idx, circuits=qc_list)
         self.circuits['untranspiled_circuits'].circuit_groups.append(circuit_group)
-        # self.untranspiled_circuits[idx].update({qubit_count: qc_list})
         return qc_list_transpiled
 
     def generate_readout_circuit(self, qubit_layout: List[int], qubit_count: int) -> CircuitGroup:
@@ -772,8 +766,6 @@ class GHZBenchmark(Benchmark):
         """
         # Generate the list of circuits
         idx = BenchmarkObservationIdentifier(qubit_layout).string_identifier
-        # self.untranspiled_circuits[idx] = {}
-        # self.transpiled_circuits[idx] = {}
 
         
         qcvv_logger.info(f"Now generating a {len(qubit_layout)}-qubit GHZ state on qubits {qubit_layout}")
@@ -787,19 +779,6 @@ class GHZBenchmark(Benchmark):
             case "coherences":
                 all_circuits_list = self.generate_coherence_meas_circuits(qubit_layout, qubit_count)
                 transpiled_ghz_group.circuits = all_circuits_list
-        # else:
-        #     all_circuits_list = transpiled_ghz_group
-
-        # self.transpiled_circuits.circuits = all_circuits_list
-        # self.transpiled_circuits = BenchmarkCircuit(
-        #     circuit_identifier=idx
-        # ):vsplit
-
-        # self.untranspiled_circuits = BenchmarkCircuit(
-        #     circuit_identifier=idx
-        # )
-
-        # self.transpiled_circuits.update({idx: all_circuits_list})
         self.circuits['transpiled_circuits'].circuit_groups.append(transpiled_ghz_group)
         return transpiled_ghz_group
 

--- a/src/iqm/benchmarks/entanglement/ghz.py
+++ b/src/iqm/benchmarks/entanglement/ghz.py
@@ -256,7 +256,6 @@ def fidelity_analysis(run: BenchmarkRunResult) -> BenchmarkAnalysisResult:
             ideal_simulator = Aer.get_backend("statevector_simulator")
             ideal_probabilities = []
             idx = BenchmarkObservationIdentifier(qubit_layout).string_identifier
-            transpiled_circuits = run.dataset.attrs["transpiled_circuits"]
             all_circuits = run.dataset.attrs["transpiled_circuits"][f"{idx}_native_ghz"].circuits
             for qc in all_circuits:
                 qc_copy = qc.copy()
@@ -699,7 +698,7 @@ class GHZBenchmark(Benchmark):
                 index_min_depth = np.argmin([c.depth() for c in ghz_native_transpiled])
                 final_ghz = ghz_native_transpiled[index_min_depth]
                 circuit_group.add_circuit([ghz_log[index_min_depth]])
-        self.circuits['untranspiled_circuits'].circuit_groups.append(circuit_group)
+        self.circuits["untranspiled_circuits"].circuit_groups.append(circuit_group)
         return CircuitGroup(name=f"{qubit_layout}_native_ghz", circuits=[final_ghz[0]])
 
     def generate_coherence_meas_circuits(self, qubit_layout: List[int], qubit_count: int) -> List[QuantumCircuit]:
@@ -718,7 +717,7 @@ class GHZBenchmark(Benchmark):
         """
 
         idx = BenchmarkObservationIdentifier(qubit_layout).string_identifier
-        qc_list = self.circuits['untranspiled_circuits'][f"{qubit_layout}_native_ghz"].circuits
+        qc_list = self.circuits["untranspiled_circuits"][f"{qubit_layout}_native_ghz"].circuits
 
         qc = qc_list[0].copy()
         qc.remove_final_measurements()
@@ -744,7 +743,7 @@ class GHZBenchmark(Benchmark):
             optimize_sqg=self.optimize_sqg,
         )
         circuit_group = CircuitGroup(name=idx, circuits=qc_list)
-        self.circuits['untranspiled_circuits'].circuit_groups.append(circuit_group)
+        self.circuits["untranspiled_circuits"].circuit_groups.append(circuit_group)
         return qc_list_transpiled
 
     def generate_readout_circuit(self, qubit_layout: List[int], qubit_count: int) -> CircuitGroup:
@@ -763,7 +762,6 @@ class GHZBenchmark(Benchmark):
                 A list of transpiled quantum circuits to be measured
         """
         # Generate the list of circuits
-        idx = BenchmarkObservationIdentifier(qubit_layout).string_identifier
 
         qcvv_logger.info(f"Now generating a {len(qubit_layout)}-qubit GHZ state on qubits {qubit_layout}")
         transpiled_ghz_group: CircuitGroup = self.generate_native_ghz(
@@ -779,7 +777,7 @@ class GHZBenchmark(Benchmark):
             case "coherences":
                 all_circuits_list = self.generate_coherence_meas_circuits(qubit_layout, qubit_count)
                 transpiled_ghz_group.circuits = all_circuits_list
-        self.circuits['transpiled_circuits'].circuit_groups.append(transpiled_ghz_group)
+        self.circuits["transpiled_circuits"].circuit_groups.append(transpiled_ghz_group)
         return transpiled_ghz_group
 
     def add_configuration_to_dataset(self, dataset: xr.Dataset):  # CHECK
@@ -798,8 +796,8 @@ class GHZBenchmark(Benchmark):
             else:
                 dataset.attrs[key] = value
         dataset.attrs[f"backend_name"] = self.backend.name
-        dataset.attrs[f"untranspiled_circuits"] = self.circuits['untranspiled_circuits']
-        dataset.attrs[f"transpiled_circuits"] = self.circuits['transpiled_circuits']
+        dataset.attrs[f"untranspiled_circuits"] = self.circuits["untranspiled_circuits"]
+        dataset.attrs[f"transpiled_circuits"] = self.circuits["transpiled_circuits"]
 
     def execute(self, backend) -> xr.Dataset:
         """
@@ -840,7 +838,7 @@ class GHZBenchmark(Benchmark):
             dataset, _ = add_counts_to_dataset(counts, idx, dataset)
             if self.rem:
                 qcvv_logger.info(f"Applying readout error mitigation")
-                circuit_group = self.circuits['transpiled_circuits'][f"{idx}_native_ghz"]
+                circuit_group = self.circuits["transpiled_circuits"][f"{idx}_native_ghz"]
                 rem_results, _ = apply_readout_error_mitigation(backend, circuit_group.circuits, counts, self.mit_shots)
                 rem_results_dist = [counts_mit.nearest_probability_distribution() for counts_mit in rem_results]
                 dataset, _ = add_counts_to_dataset(rem_results_dist, f"{idx}_rem", dataset)

--- a/src/iqm/benchmarks/optimization/qscore.py
+++ b/src/iqm/benchmarks/optimization/qscore.py
@@ -26,12 +26,12 @@ import matplotlib.pyplot as plt
 from networkx import Graph
 import networkx as nx
 import numpy as np
-from qiskit import QuantumCircuit
 from scipy.optimize import basinhopping, minimize
 
 from iqm.benchmarks.benchmark import BenchmarkBase, BenchmarkConfigurationBase
 from iqm.benchmarks.logging_config import qcvv_logger
 from iqm.benchmarks.utils import perform_backend_transpilation, retrieve_all_counts, submit_execute, timeit
+from iqm.qiskit_iqm import IQMCircuit as QuantumCircuit
 from iqm.qiskit_iqm.iqm_backend import IQMBackendBase
 
 

--- a/src/iqm/benchmarks/quantum_volume/clops.py
+++ b/src/iqm/benchmarks/quantum_volume/clops.py
@@ -29,10 +29,10 @@ from qiskit import QuantumCircuit
 from qiskit.circuit import ParameterVector
 import xarray as xr
 
-from iqm.benchmarks.circuit_containers import Circuits, CircuitGroup, BenchmarkCircuit
 from iqm.benchmarks import Benchmark
 from iqm.benchmarks.benchmark import BenchmarkConfigurationBase
 from iqm.benchmarks.benchmark_definition import BenchmarkAnalysisResult, BenchmarkRunResult
+from iqm.benchmarks.circuit_containers import BenchmarkCircuit, CircuitGroup, Circuits
 from iqm.benchmarks.logging_config import qcvv_logger
 from iqm.benchmarks.utils import (
     count_2q_layers,

--- a/src/iqm/benchmarks/quantum_volume/quantum_volume.py
+++ b/src/iqm/benchmarks/quantum_volume/quantum_volume.py
@@ -821,7 +821,6 @@ class QuantumVolumeBenchmark(Benchmark):
             qcvv_logger.info(f"Adding counts of {qubits} run to the dataset")
             dataset, _ = add_counts_to_dataset(execution_results, str(qubits), dataset)
 
-        # self.add_all_circuits_to_dataset(dataset)
         self.circuits = Circuits([self.transpiled_circuits, self.untranspiled_circuits])
 
         if self.rem:

--- a/src/iqm/benchmarks/quantum_volume/quantum_volume.py
+++ b/src/iqm/benchmarks/quantum_volume/quantum_volume.py
@@ -25,7 +25,6 @@ import matplotlib.pyplot as plt
 from mthree.classes import QuasiCollection
 from mthree.utils import expval
 import numpy as np
-from qiskit import QuantumCircuit
 from qiskit.circuit.library import QuantumVolume
 from qiskit_aer import Aer
 import xarray as xr
@@ -57,6 +56,7 @@ from iqm.benchmarks.utils import (  # execute_with_dd,
     timeit,
     xrvariable_to_counts,
 )
+from iqm.qiskit_iqm import IQMCircuit as QuantumCircuit
 from iqm.qiskit_iqm.iqm_backend import IQMBackendBase
 
 
@@ -324,15 +324,7 @@ def qv_analysis(run: BenchmarkRunResult) -> BenchmarkAnalysisResult:
         # Retrieve other dataset values
         dataset_dictionary = dataset.attrs[qubits_idx]
         sorted_qc_list_indices = dataset_dictionary["sorted_qc_list_indices"]
-        transpiled_qc_list = run.circuits["transpiled_circuits"][str(qubits)].circuits
         qc_list = run.circuits["untranspiled_circuits"][str(qubits)].circuits
-        # qc_list = []
-        # transpiled_circ_dataset = dataset.attrs["transpiled_circuits"][str(qubits)]
-        # transpiled_qc_list = []
-        # untranspiled_circ_dataset = dataset.attrs["untranspiled_circuits"][str(qubits)]
-        # for key in transpiled_circ_dataset:  # Keys (final layouts) are the same for transp/untransp
-        #     transpiled_qc_list.extend(transpiled_circ_dataset[key])
-        #     qc_list.extend(untranspiled_circ_dataset[key])
 
         qv_results_type[str(qubits)] = dataset_dictionary["qv_results_type"]
         depth[str(qubits)] = len(qubits)
@@ -749,8 +741,6 @@ class QuantumVolumeBenchmark(Benchmark):
 
         for qubits in self.custom_qubits_array:  # NB: jobs will be submitted for qubit layouts in the specified order
 
-            # self.untranspiled_circuits[str(qubits)] = {}
-            # self.transpiled_circuits[str(qubits)] = {}
             num_qubits = len(qubits)
             depth = num_qubits
             qcvv_logger.info(f"Executing QV on qubits {qubits}")
@@ -787,21 +777,9 @@ class QuantumVolumeBenchmark(Benchmark):
             else:
                 raise ValueError("physical_layout must either be \"fixed\" or \"batching\"")
 
-            # self.untranspiled_circuits[str(qubits)].update({tuple(qubits): qc_list})
-            # self.transpiled_circuits[str(qubits)].update(sorted_transpiled_qc_list)
-            self.transpiled_circuits.circuit_groups.append(
-                CircuitGroup(
-                    name = str(qubits),
-                    circuits = qc_list
-                )
-
-            )
+            self.transpiled_circuits.circuit_groups.append(CircuitGroup(name=str(qubits), circuits=qc_list))
             self.untranspiled_circuits.circuit_groups.append(
-                CircuitGroup(
-                    name = str(qubits),
-                    circuits = sorted_transpiled_qc_list[tuple(qubits)]
-                )
-
+                CircuitGroup(name=str(qubits), circuits=sorted_transpiled_qc_list[tuple(qubits)])
             )
 
             # Count operations

--- a/src/iqm/benchmarks/quantum_volume/quantum_volume.py
+++ b/src/iqm/benchmarks/quantum_volume/quantum_volume.py
@@ -324,7 +324,7 @@ def qv_analysis(run: BenchmarkRunResult) -> BenchmarkAnalysisResult:
         # Retrieve other dataset values
         dataset_dictionary = dataset.attrs[qubits_idx]
         sorted_qc_list_indices = dataset_dictionary["sorted_qc_list_indices"]
-        qc_list = run.circuits["untranspiled_circuits"][str(qubits)].circuits
+        qc_list = run.circuits["transpiled_circuits"][str(qubits)].circuits
 
         qv_results_type[str(qubits)] = dataset_dictionary["qv_results_type"]
         depth[str(qubits)] = len(qubits)
@@ -777,8 +777,8 @@ class QuantumVolumeBenchmark(Benchmark):
             else:
                 raise ValueError("physical_layout must either be \"fixed\" or \"batching\"")
 
-            self.transpiled_circuits.circuit_groups.append(CircuitGroup(name=str(qubits), circuits=qc_list))
-            self.untranspiled_circuits.circuit_groups.append(
+            self.untranspiled_circuits.circuit_groups.append(CircuitGroup(name=str(qubits), circuits=qc_list))
+            self.transpiled_circuits.circuit_groups.append(
                 CircuitGroup(name=str(qubits), circuits=sorted_transpiled_qc_list[tuple(qubits)])
             )
 

--- a/src/iqm/benchmarks/quantum_volume/quantum_volume.py
+++ b/src/iqm/benchmarks/quantum_volume/quantum_volume.py
@@ -30,9 +30,6 @@ from qiskit.circuit.library import QuantumVolume
 from qiskit_aer import Aer
 import xarray as xr
 
-# import iqm.diqe.executors.dynamical_decoupling.dd_high_level as dd
-# from iqm.diqe.executors.dynamical_decoupling.dynamical_decoupling_core import DDStrategy
-# from iqm.diqe.mapomatic import evaluate_costs, get_calibration_fidelities, get_circuit, matching_layouts
 from iqm.benchmarks.benchmark import BenchmarkConfigurationBase
 from iqm.benchmarks.benchmark_definition import (
     Benchmark,
@@ -42,6 +39,11 @@ from iqm.benchmarks.benchmark_definition import (
     BenchmarkRunResult,
     add_counts_to_dataset,
 )
+
+# import iqm.diqe.executors.dynamical_decoupling.dd_high_level as dd
+# from iqm.diqe.executors.dynamical_decoupling.dynamical_decoupling_core import DDStrategy
+# from iqm.diqe.mapomatic import evaluate_costs, get_calibration_fidelities, get_circuit, matching_layouts
+from iqm.benchmarks.circuit_containers import BenchmarkCircuit, CircuitGroup, Circuits
 from iqm.benchmarks.logging_config import qcvv_logger
 from iqm.benchmarks.readout_mitigation import apply_readout_error_mitigation
 from iqm.benchmarks.utils import (  # execute_with_dd,
@@ -322,13 +324,15 @@ def qv_analysis(run: BenchmarkRunResult) -> BenchmarkAnalysisResult:
         # Retrieve other dataset values
         dataset_dictionary = dataset.attrs[qubits_idx]
         sorted_qc_list_indices = dataset_dictionary["sorted_qc_list_indices"]
-        transpiled_circ_dataset = dataset.attrs["transpiled_circuits"][str(qubits)]
-        transpiled_qc_list = []
-        untranspiled_circ_dataset = dataset.attrs["untranspiled_circuits"][str(qubits)]
-        qc_list = []
-        for key in transpiled_circ_dataset:  # Keys (final layouts) are the same for transp/untransp
-            transpiled_qc_list.extend(transpiled_circ_dataset[key])
-            qc_list.extend(untranspiled_circ_dataset[key])
+        transpiled_qc_list = run.circuits["transpiled_circuits"][str(qubits)].circuits
+        qc_list = run.circuits["untranspiled_circuits"][str(qubits)].circuits
+        # qc_list = []
+        # transpiled_circ_dataset = dataset.attrs["transpiled_circuits"][str(qubits)]
+        # transpiled_qc_list = []
+        # untranspiled_circ_dataset = dataset.attrs["untranspiled_circuits"][str(qubits)]
+        # for key in transpiled_circ_dataset:  # Keys (final layouts) are the same for transp/untransp
+        #     transpiled_qc_list.extend(transpiled_circ_dataset[key])
+        #     qc_list.extend(untranspiled_circ_dataset[key])
 
         qv_results_type[str(qubits)] = dataset_dictionary["qv_results_type"]
         depth[str(qubits)] = len(qubits)
@@ -738,13 +742,15 @@ class QuantumVolumeBenchmark(Benchmark):
         sorted_qc_list_indices = {}
 
         # Initialize the variable to contain the QV circuits of each layout
-        self.untranspiled_circuits: Dict[str, Dict[Tuple, List[QuantumCircuit]]] = {}
-        self.transpiled_circuits: Dict[str, Dict[Tuple, List[QuantumCircuit]]] = {}
+        self.circuits = Circuits()
+        self.untranspiled_circuits = BenchmarkCircuit(name="untranspiled_circuits")
+        self.transpiled_circuits = BenchmarkCircuit(name="transpiled_circuits")
         all_op_counts = {}
 
         for qubits in self.custom_qubits_array:  # NB: jobs will be submitted for qubit layouts in the specified order
-            self.untranspiled_circuits[str(qubits)] = {}
-            self.transpiled_circuits[str(qubits)] = {}
+
+            # self.untranspiled_circuits[str(qubits)] = {}
+            # self.transpiled_circuits[str(qubits)] = {}
             num_qubits = len(qubits)
             depth = num_qubits
             qcvv_logger.info(f"Executing QV on qubits {qubits}")
@@ -781,8 +787,22 @@ class QuantumVolumeBenchmark(Benchmark):
             else:
                 raise ValueError("physical_layout must either be \"fixed\" or \"batching\"")
 
-            self.untranspiled_circuits[str(qubits)].update({tuple(qubits): qc_list})
-            self.transpiled_circuits[str(qubits)].update(sorted_transpiled_qc_list)
+            # self.untranspiled_circuits[str(qubits)].update({tuple(qubits): qc_list})
+            # self.transpiled_circuits[str(qubits)].update(sorted_transpiled_qc_list)
+            self.transpiled_circuits.circuit_groups.append(
+                CircuitGroup(
+                    name = str(qubits),
+                    circuits = qc_list
+                )
+
+            )
+            self.untranspiled_circuits.circuit_groups.append(
+                CircuitGroup(
+                    name = str(qubits),
+                    circuits = sorted_transpiled_qc_list[tuple(qubits)]
+                )
+
+            )
 
             # Count operations
             all_op_counts[str(qubits)] = count_native_gates(backend, transpiled_qc_list)
@@ -823,14 +843,16 @@ class QuantumVolumeBenchmark(Benchmark):
             qcvv_logger.info(f"Adding counts of {qubits} run to the dataset")
             dataset, _ = add_counts_to_dataset(execution_results, str(qubits), dataset)
 
-        self.add_all_circuits_to_dataset(dataset)
+        # self.add_all_circuits_to_dataset(dataset)
+        self.circuits = Circuits([self.transpiled_circuits, self.untranspiled_circuits])
 
         if self.rem:
             rem_quasidistros = {}
             for qubits in self.custom_qubits_array:
                 exec_counts = xrvariable_to_counts(dataset, str(qubits), self.num_circuits)
                 rem_quasidistros[f"REM_quasidist_{str(qubits)}"] = self.get_rem_quasidistro(
-                    self.transpiled_circuits[str(qubits)],
+                    {tuple(qubits): self.transpiled_circuits[str(qubits)].circuits},
+                    # self.transpiled_circuits[str(qubits)],
                     sorted_qc_list_indices[str(qubits)],
                     exec_counts,
                     self.mit_shots,

--- a/src/iqm/benchmarks/randomized_benchmarking/clifford_rb/clifford_rb.py
+++ b/src/iqm/benchmarks/randomized_benchmarking/clifford_rb/clifford_rb.py
@@ -20,7 +20,6 @@ from time import strftime
 from typing import Any, Dict, List, Sequence, Type
 
 import numpy as np
-from qiskit import QuantumCircuit
 import xarray as xr
 
 from iqm.benchmarks.benchmark import BenchmarkConfigurationBase
@@ -49,6 +48,7 @@ from iqm.benchmarks.randomized_benchmarking.randomized_benchmarking_common impor
     validate_rb_qubits,
 )
 from iqm.benchmarks.utils import retrieve_all_counts, retrieve_all_job_metadata, timeit, xrvariable_to_counts
+from iqm.qiskit_iqm import IQMCircuit as QuantumCircuit
 from iqm.qiskit_iqm.iqm_backend import IQMBackendBase
 
 

--- a/src/iqm/benchmarks/randomized_benchmarking/clifford_rb/clifford_rb.py
+++ b/src/iqm/benchmarks/randomized_benchmarking/clifford_rb/clifford_rb.py
@@ -245,8 +245,6 @@ class CliffordRandomizedBenchmarking(Benchmark):
         # Initialize the variable to contain the circuits for each layout
         self.untranspiled_circuits = BenchmarkCircuit("untranspiled_circuits")
         self.transpiled_circuits = BenchmarkCircuit("transpiled_circuits")
-        # self.untranspiled_circuits: Dict[str, Dict[int, List[QuantumCircuit]]] = {}
-        # self.transpiled_circuits: Dict[str, Dict[int, List[QuantumCircuit]]] = {}
 
         # Auxiliary dict from str(qubits) to indices
         qubit_idx: Dict[str, Any] = {}
@@ -306,13 +304,6 @@ class CliffordRandomizedBenchmarking(Benchmark):
                         circuits=parallel_transpiled_rb_circuits[seq_length],
                     )
                 )
-            # self.untranspiled_circuits[str(self.qubits_array)] = {
-            #     m: parallel_untranspiled_rb_circuits[m] for m in self.sequence_lengths
-            # }
-            # self.transpiled_circuits[str(self.qubits_array)] = {
-            #     m: parallel_transpiled_rb_circuits[m] for m in self.sequence_lengths
-            # }
-
             qubit_idx = {str(self.qubits_array): "parallel_all"}
             dataset.attrs["parallel_all"] = {"qubits": self.qubits_array}
             dataset.attrs.update({q_idx: {"qubits": q} for q_idx, q in enumerate(self.qubits_array)})
@@ -368,8 +359,6 @@ class CliffordRandomizedBenchmarking(Benchmark):
                 self.transpiled_circuits.circuit_groups.append(
                     CircuitGroup(name=str(qubits), circuits=rb_transpiled_circuits[str(qubits)])
                 )
-                # self.untranspiled_circuits[str(qubits)]=rb_untranspiled_circuits[str(qubits)]
-                # self.transpiled_circuits[str(qubits)]=rb_transpiled_circuits[str(qubits)]
 
                 dataset.attrs[qubits_idx] = {"qubits": qubits}
 
@@ -397,8 +386,6 @@ class CliffordRandomizedBenchmarking(Benchmark):
 
             qcvv_logger.info(f"Adding counts of qubits {qubits} and depth {depth} run to the dataset")
             dataset, _ = add_counts_to_dataset(execution_results, identifier, dataset)
-
-        # self.add_all_circuits_to_dataset(dataset)
 
         qcvv_logger.info(f"RB experiment concluded !")
         self.circuits = Circuits([self.transpiled_circuits, self.untranspiled_circuits])

--- a/src/iqm/benchmarks/randomized_benchmarking/clifford_rb/clifford_rb.py
+++ b/src/iqm/benchmarks/randomized_benchmarking/clifford_rb/clifford_rb.py
@@ -23,7 +23,6 @@ import numpy as np
 from qiskit import QuantumCircuit
 import xarray as xr
 
-from iqm.benchmarks.circuit_containers import Circuits, CircuitGroup, BenchmarkCircuit
 from iqm.benchmarks.benchmark import BenchmarkConfigurationBase
 from iqm.benchmarks.benchmark_definition import (
     Benchmark,
@@ -33,6 +32,7 @@ from iqm.benchmarks.benchmark_definition import (
     BenchmarkRunResult,
     add_counts_to_dataset,
 )
+from iqm.benchmarks.circuit_containers import BenchmarkCircuit, CircuitGroup, Circuits
 from iqm.benchmarks.logging_config import qcvv_logger
 from iqm.benchmarks.randomized_benchmarking.randomized_benchmarking_common import (
     exponential_rb,
@@ -297,12 +297,13 @@ class CliffordRandomizedBenchmarking(Benchmark):
                 self.untranspiled_circuits.circuit_groups.append(
                     CircuitGroup(
                         name=f"{str(self.qubits_array)}_length_{seq_length}",
-                        circuits=parallel_untranspiled_rb_circuits[seq_length]
-                ))
+                        circuits=parallel_untranspiled_rb_circuits[seq_length],
+                    )
+                )
                 self.transpiled_circuits.circuit_groups.append(
                     CircuitGroup(
                         name=f"{str(self.qubits_array)}_length_{seq_length}",
-                        circuits=parallel_transpiled_rb_circuits[seq_length]
+                        circuits=parallel_transpiled_rb_circuits[seq_length],
                     )
                 )
             # self.untranspiled_circuits[str(self.qubits_array)] = {
@@ -362,32 +363,26 @@ class CliffordRandomizedBenchmarking(Benchmark):
                 )
 
                 self.untranspiled_circuits.circuit_groups.append(
-                    CircuitGroup(
-                        name=str(qubits),
-                        circuits=rb_untranspiled_circuits[str(qubits)]
-                    )
+                    CircuitGroup(name=str(qubits), circuits=rb_untranspiled_circuits[str(qubits)])
                 )
                 self.transpiled_circuits.circuit_groups.append(
-                    CircuitGroup(
-                        name=str(qubits),
-                        circuits=rb_transpiled_circuits[str(qubits)]
-                    )
+                    CircuitGroup(name=str(qubits), circuits=rb_transpiled_circuits[str(qubits)])
                 )
                 # self.untranspiled_circuits[str(qubits)]=rb_untranspiled_circuits[str(qubits)]
                 # self.transpiled_circuits[str(qubits)]=rb_transpiled_circuits[str(qubits)]
 
-                dataset.attrs[qubits_idx]={"qubits": qubits}
+                dataset.attrs[qubits_idx] = {"qubits": qubits}
 
         # Retrieve counts of jobs for all qubit layouts
-        all_job_metadata={}
+        all_job_metadata = {}
         for job_dict in all_rb_jobs:
-            qubits=job_dict["qubits"]
-            depth=job_dict["depth"]
+            qubits = job_dict["qubits"]
+            depth = job_dict["depth"]
             # Retrieve counts
-            identifier=f"qubits_{str(qubits)}_depth_{str(depth)}"
-            execution_results, time_retrieve=retrieve_all_counts(job_dict["jobs"], identifier)
+            identifier = f"qubits_{str(qubits)}_depth_{str(depth)}"
+            execution_results, time_retrieve = retrieve_all_counts(job_dict["jobs"], identifier)
             # Retrieve all job meta data
-            all_job_metadata=retrieve_all_job_metadata(job_dict["jobs"])
+            all_job_metadata = retrieve_all_job_metadata(job_dict["jobs"])
             # Export all to dataset
             dataset.attrs[qubit_idx[str(qubits)]].update(
                 {
@@ -401,7 +396,7 @@ class CliffordRandomizedBenchmarking(Benchmark):
             )
 
             qcvv_logger.info(f"Adding counts of qubits {qubits} and depth {depth} run to the dataset")
-            dataset, _=add_counts_to_dataset(execution_results, identifier, dataset)
+            dataset, _ = add_counts_to_dataset(execution_results, identifier, dataset)
 
         # self.add_all_circuits_to_dataset(dataset)
 
@@ -424,8 +419,8 @@ class CliffordRBConfiguration(BenchmarkConfigurationBase):
                             * Default is False.
     """
 
-    benchmark: Type[Benchmark]=CliffordRandomizedBenchmarking
+    benchmark: Type[Benchmark] = CliffordRandomizedBenchmarking
     qubits_array: Sequence[Sequence[int]]
     sequence_lengths: Sequence[int]
     num_circuit_samples: int
-    parallel_execution: bool=False
+    parallel_execution: bool = False

--- a/src/iqm/benchmarks/randomized_benchmarking/interleaved_rb/interleaved_rb.py
+++ b/src/iqm/benchmarks/randomized_benchmarking/interleaved_rb/interleaved_rb.py
@@ -221,13 +221,6 @@ def interleaved_rb_analysis(run: BenchmarkRunResult) -> BenchmarkAnalysisResult:
         )
         plots[fig_name] = fig
 
-    # Rearrange observations
-    # observations_refactored: Dict[int, Dict[str, Dict[str, float]]] = {}
-    # for k, o in obs_dict.items():
-    #     observations_refactored[k] = {}
-    #     for rb_type in o.keys():
-    #         observations_refactored[k].update({f"{k}_{rb_type}": v for k, v in o[rb_type].items()})
-
     return BenchmarkAnalysisResult(dataset=dataset, observations=observations, plots=plots)
 
 
@@ -311,8 +304,6 @@ class InterleavedRandomizedBenchmarking(Benchmark):
         time_circuit_generation: Dict[str, float] = {}
 
         # Initialize the variable to contain the circuits for each layout
-        # self.untranspiled_circuits: Dict[str, Dict[int, List[QuantumCircuit]]] = {}
-        # self.transpiled_circuits: Dict[str, Dict[int, List[QuantumCircuit]]] = {}
 
         self.untranspiled_circuits = BenchmarkCircuit("untranspiled_circuits")
         self.transpiled_circuits = BenchmarkCircuit("transpiled_circuits")
@@ -422,12 +413,6 @@ class InterleavedRandomizedBenchmarking(Benchmark):
                     circuits=[parallel_transpiled_rb_circuits[m] for m in self.sequence_lengths],
                 )
             )
-            # self.untranspiled_circuits[str(self.qubits_array)] = {
-            #     m: parallel_untranspiled_rb_circuits[m] for m in self.sequence_lengths
-            # }
-            # self.transpiled_circuits[str(self.qubits_array)] = {
-            #     m: parallel_transpiled_rb_circuits[m] for m in self.sequence_lengths
-            # }
             self.untranspiled_circuits.circuit_groups.append(
                 CircuitGroup(
                     name=f"{str(self.qubits_array)}_interleaved",
@@ -440,12 +425,6 @@ class InterleavedRandomizedBenchmarking(Benchmark):
                     circuits=[parallel_transpiled_interleaved_rb_circuits[m] for m in self.sequence_lengths],
                 )
             )
-            # self.untranspiled_circuits[str(self.qubits_array) + "_interleaved"] = {
-            #     m: parallel_untranspiled_interleaved_rb_circuits[m] for m in self.sequence_lengths
-            # }
-            # self.transpiled_circuits[str(self.qubits_array) + "_interleaved"] = {
-            #     m: parallel_transpiled_interleaved_rb_circuits[m] for m in self.sequence_lengths
-            # }
 
             qubit_idx = {str(self.qubits_array): "parallel_all"}
             dataset.attrs["parallel_all"] = {"qubits": self.qubits_array}
@@ -548,12 +527,6 @@ class InterleavedRandomizedBenchmarking(Benchmark):
                         circuits=[rb_transpiled_interleaved_circuits[str(qubits)]],
                     )
                 )
-                # self.untranspiled_circuits[str(qubits)] = rb_untranspiled_circuits[str(qubits)]
-                # self.transpiled_circuits[str(qubits)] = rb_transpiled_circuits[str(qubits)]
-                # self.untranspiled_circuits[str(qubits) + "_interleaved"] = rb_untranspiled_interleaved_circuits[
-                #     str(qubits)
-                # ]
-                # self.transpiled_circuits[str(qubits) + "_interleaved"] = rb_transpiled_interleaved_circuits[str(qubits)]
 
                 dataset.attrs[qubits_idx] = {"qubits": qubits}
 
@@ -584,8 +557,6 @@ class InterleavedRandomizedBenchmarking(Benchmark):
 
                 qcvv_logger.info(f"Adding counts of qubits {qubits} and depth {depth} run to the dataset")
                 dataset, _ = add_counts_to_dataset(execution_results, identifier, dataset)
-
-        # self.add_all_circuits_to_dataset(dataset)
 
         qcvv_logger.info(f"Interleaved RB experiment concluded !")
         self.circuits = Circuits([self.transpiled_circuits, self.untranspiled_circuits])

--- a/src/iqm/benchmarks/randomized_benchmarking/interleaved_rb/interleaved_rb.py
+++ b/src/iqm/benchmarks/randomized_benchmarking/interleaved_rb/interleaved_rb.py
@@ -24,6 +24,7 @@ import numpy as np
 from qiskit import QuantumCircuit
 import xarray as xr
 
+from iqm.benchmarks.circuit_containers import CircuitGroup, Circuits, BenchmarkCircuit
 from iqm.benchmarks.benchmark import BenchmarkConfigurationBase
 from iqm.benchmarks.benchmark_definition import (
     Benchmark,
@@ -310,9 +311,11 @@ class InterleavedRandomizedBenchmarking(Benchmark):
         time_circuit_generation: Dict[str, float] = {}
 
         # Initialize the variable to contain the circuits for each layout
-        self.untranspiled_circuits: Dict[str, Dict[int, List[QuantumCircuit]]] = {}
-        self.transpiled_circuits: Dict[str, Dict[int, List[QuantumCircuit]]] = {}
+        # self.untranspiled_circuits: Dict[str, Dict[int, List[QuantumCircuit]]] = {}
+        # self.transpiled_circuits: Dict[str, Dict[int, List[QuantumCircuit]]] = {}
 
+        self.untranspiled_circuits = BenchmarkCircuit("untranspiled_circuits")
+        self.transpiled_circuits = BenchmarkCircuit("transpiled_circuits")
         # Validate and get interleaved gate as a QC
         interleaved_gate_qc = validate_irb_gate(
             self.interleaved_gate, backend, gate_params=self.interleaved_gate_params
@@ -407,18 +410,42 @@ class InterleavedRandomizedBenchmarking(Benchmark):
                 )
                 qcvv_logger.info(f"Both jobs for sequence length {seq_length} submitted successfully!")
 
-            self.untranspiled_circuits[str(self.qubits_array)] = {
-                m: parallel_untranspiled_rb_circuits[m] for m in self.sequence_lengths
-            }
-            self.transpiled_circuits[str(self.qubits_array)] = {
-                m: parallel_transpiled_rb_circuits[m] for m in self.sequence_lengths
-            }
-            self.untranspiled_circuits[str(self.qubits_array) + "_interleaved"] = {
-                m: parallel_untranspiled_interleaved_rb_circuits[m] for m in self.sequence_lengths
-            }
-            self.transpiled_circuits[str(self.qubits_array) + "_interleaved"] = {
-                m: parallel_transpiled_interleaved_rb_circuits[m] for m in self.sequence_lengths
-            }
+            self.untranspiled_circuits.circuit_groups.append(
+                CircuitGroup(
+                    name=str(self.qubits_array),
+                    circuits=[parallel_untranspiled_rb_circuits[m] for m in self.sequence_lengths]
+                )
+            )
+            self.transpiled_circuits.circuit_groups.append(
+                CircuitGroup(
+                    name=str(self.qubits_array),
+                    circuits=[parallel_transpiled_rb_circuits[m] for m in self.sequence_lengths]
+                )
+            )
+            # self.untranspiled_circuits[str(self.qubits_array)] = {
+            #     m: parallel_untranspiled_rb_circuits[m] for m in self.sequence_lengths
+            # }
+            # self.transpiled_circuits[str(self.qubits_array)] = {
+            #     m: parallel_transpiled_rb_circuits[m] for m in self.sequence_lengths
+            # }
+            self.untranspiled_circuits.circuit_groups.append(
+                CircuitGroup(
+                    name=f"{str(self.qubits_array)}_interleaved",
+                    circuits=[parallel_untranspiled_interleaved_rb_circuits[m] for m in self.sequence_lengths]
+                )
+            )
+            self.transpiled_circuits.circuit_groups.append(
+                CircuitGroup(
+                    name=f"{str(self.qubits_array)}_interleaved",
+                    circuits=[parallel_transpiled_interleaved_rb_circuits[m] for m in self.sequence_lengths]
+                )
+            )
+            # self.untranspiled_circuits[str(self.qubits_array) + "_interleaved"] = {
+            #     m: parallel_untranspiled_interleaved_rb_circuits[m] for m in self.sequence_lengths
+            # }
+            # self.transpiled_circuits[str(self.qubits_array) + "_interleaved"] = {
+            #     m: parallel_transpiled_interleaved_rb_circuits[m] for m in self.sequence_lengths
+            # }
 
             qubit_idx = {str(self.qubits_array): "parallel_all"}
             dataset.attrs["parallel_all"] = {"qubits": self.qubits_array}
@@ -502,12 +529,38 @@ class InterleavedRandomizedBenchmarking(Benchmark):
                     f"All jobs for qubits {qubits} and sequence lengths {self.sequence_lengths} submitted successfully!"
                 )
 
-                self.untranspiled_circuits[str(qubits)] = rb_untranspiled_circuits[str(qubits)]
-                self.transpiled_circuits[str(qubits)] = rb_transpiled_circuits[str(qubits)]
-                self.untranspiled_circuits[str(qubits) + "_interleaved"] = rb_untranspiled_interleaved_circuits[
-                    str(qubits)
-                ]
-                self.transpiled_circuits[str(qubits) + "_interleaved"] = rb_transpiled_interleaved_circuits[str(qubits)]
+                self.untranspiled_circuits.circuit_groups.append(
+                    CircuitGroup(
+                        name=str(qubits),
+                        circuits=[rb_untranspiled_circuits[str(qubits)]]
+                    )
+                )
+                self.transpiled_circuits.circuit_groups.append(
+                    CircuitGroup(
+                        name=str(qubits),
+                        circuits=[rb_transpiled_circuits[str(qubits)]]
+                    )
+                )
+
+                self.untranspiled_circuits.circuit_groups.append(
+                    CircuitGroup(
+                        name=f"{str(qubits)}_interleaved",
+                        circuits=[rb_untranspiled_interleaved_circuits[str(qubits)]]
+                    )
+                )
+                self.transpiled_circuits.circuit_groups.append(
+                    CircuitGroup(
+                        name=f"{str(qubits)}_interleaved",
+                        # name=str(qubits),
+                        circuits=[rb_transpiled_interleaved_circuits[str(qubits)]]
+                    )
+                )
+                # self.untranspiled_circuits[str(qubits)] = rb_untranspiled_circuits[str(qubits)]
+                # self.transpiled_circuits[str(qubits)] = rb_transpiled_circuits[str(qubits)]
+                # self.untranspiled_circuits[str(qubits) + "_interleaved"] = rb_untranspiled_interleaved_circuits[
+                #     str(qubits)
+                # ]
+                # self.transpiled_circuits[str(qubits) + "_interleaved"] = rb_transpiled_interleaved_circuits[str(qubits)]
 
                 dataset.attrs[qubits_idx] = {"qubits": qubits}
 
@@ -539,9 +592,10 @@ class InterleavedRandomizedBenchmarking(Benchmark):
                 qcvv_logger.info(f"Adding counts of qubits {qubits} and depth {depth} run to the dataset")
                 dataset, _ = add_counts_to_dataset(execution_results, identifier, dataset)
 
-        self.add_all_circuits_to_dataset(dataset)
+        # self.add_all_circuits_to_dataset(dataset)
 
         qcvv_logger.info(f"Interleaved RB experiment concluded !")
+        self.circuits = Circuits([self.transpiled_circuits, self.untranspiled_circuits])
 
         return dataset
 

--- a/src/iqm/benchmarks/randomized_benchmarking/interleaved_rb/interleaved_rb.py
+++ b/src/iqm/benchmarks/randomized_benchmarking/interleaved_rb/interleaved_rb.py
@@ -24,7 +24,6 @@ import numpy as np
 from qiskit import QuantumCircuit
 import xarray as xr
 
-from iqm.benchmarks.circuit_containers import CircuitGroup, Circuits, BenchmarkCircuit
 from iqm.benchmarks.benchmark import BenchmarkConfigurationBase
 from iqm.benchmarks.benchmark_definition import (
     Benchmark,
@@ -34,6 +33,7 @@ from iqm.benchmarks.benchmark_definition import (
     BenchmarkRunResult,
     add_counts_to_dataset,
 )
+from iqm.benchmarks.circuit_containers import BenchmarkCircuit, CircuitGroup, Circuits
 from iqm.benchmarks.logging_config import qcvv_logger
 from iqm.benchmarks.randomized_benchmarking.randomized_benchmarking_common import (
     exponential_rb,
@@ -413,13 +413,13 @@ class InterleavedRandomizedBenchmarking(Benchmark):
             self.untranspiled_circuits.circuit_groups.append(
                 CircuitGroup(
                     name=str(self.qubits_array),
-                    circuits=[parallel_untranspiled_rb_circuits[m] for m in self.sequence_lengths]
+                    circuits=[parallel_untranspiled_rb_circuits[m] for m in self.sequence_lengths],
                 )
             )
             self.transpiled_circuits.circuit_groups.append(
                 CircuitGroup(
                     name=str(self.qubits_array),
-                    circuits=[parallel_transpiled_rb_circuits[m] for m in self.sequence_lengths]
+                    circuits=[parallel_transpiled_rb_circuits[m] for m in self.sequence_lengths],
                 )
             )
             # self.untranspiled_circuits[str(self.qubits_array)] = {
@@ -431,13 +431,13 @@ class InterleavedRandomizedBenchmarking(Benchmark):
             self.untranspiled_circuits.circuit_groups.append(
                 CircuitGroup(
                     name=f"{str(self.qubits_array)}_interleaved",
-                    circuits=[parallel_untranspiled_interleaved_rb_circuits[m] for m in self.sequence_lengths]
+                    circuits=[parallel_untranspiled_interleaved_rb_circuits[m] for m in self.sequence_lengths],
                 )
             )
             self.transpiled_circuits.circuit_groups.append(
                 CircuitGroup(
                     name=f"{str(self.qubits_array)}_interleaved",
-                    circuits=[parallel_transpiled_interleaved_rb_circuits[m] for m in self.sequence_lengths]
+                    circuits=[parallel_transpiled_interleaved_rb_circuits[m] for m in self.sequence_lengths],
                 )
             )
             # self.untranspiled_circuits[str(self.qubits_array) + "_interleaved"] = {
@@ -530,29 +530,22 @@ class InterleavedRandomizedBenchmarking(Benchmark):
                 )
 
                 self.untranspiled_circuits.circuit_groups.append(
-                    CircuitGroup(
-                        name=str(qubits),
-                        circuits=[rb_untranspiled_circuits[str(qubits)]]
-                    )
+                    CircuitGroup(name=str(qubits), circuits=[rb_untranspiled_circuits[str(qubits)]])
                 )
                 self.transpiled_circuits.circuit_groups.append(
-                    CircuitGroup(
-                        name=str(qubits),
-                        circuits=[rb_transpiled_circuits[str(qubits)]]
-                    )
+                    CircuitGroup(name=str(qubits), circuits=[rb_transpiled_circuits[str(qubits)]])
                 )
 
                 self.untranspiled_circuits.circuit_groups.append(
                     CircuitGroup(
-                        name=f"{str(qubits)}_interleaved",
-                        circuits=[rb_untranspiled_interleaved_circuits[str(qubits)]]
+                        name=f"{str(qubits)}_interleaved", circuits=[rb_untranspiled_interleaved_circuits[str(qubits)]]
                     )
                 )
                 self.transpiled_circuits.circuit_groups.append(
                     CircuitGroup(
                         name=f"{str(qubits)}_interleaved",
                         # name=str(qubits),
-                        circuits=[rb_transpiled_interleaved_circuits[str(qubits)]]
+                        circuits=[rb_transpiled_interleaved_circuits[str(qubits)]],
                     )
                 )
                 # self.untranspiled_circuits[str(qubits)] = rb_untranspiled_circuits[str(qubits)]

--- a/src/iqm/benchmarks/randomized_benchmarking/interleaved_rb/interleaved_rb.py
+++ b/src/iqm/benchmarks/randomized_benchmarking/interleaved_rb/interleaved_rb.py
@@ -21,7 +21,6 @@ from typing import Any, Dict, List, Literal, Optional, Sequence, Type
 
 from matplotlib.figure import Figure
 import numpy as np
-from qiskit import QuantumCircuit
 import xarray as xr
 
 from iqm.benchmarks.benchmark import BenchmarkConfigurationBase
@@ -51,6 +50,7 @@ from iqm.benchmarks.randomized_benchmarking.randomized_benchmarking_common impor
     validate_rb_qubits,
 )
 from iqm.benchmarks.utils import retrieve_all_counts, retrieve_all_job_metadata, timeit, xrvariable_to_counts
+from iqm.qiskit_iqm import IQMCircuit as QuantumCircuit
 from iqm.qiskit_iqm.iqm_backend import IQMBackendBase
 
 

--- a/src/iqm/benchmarks/randomized_benchmarking/mirror_rb/mirror_rb.py
+++ b/src/iqm/benchmarks/randomized_benchmarking/mirror_rb/mirror_rb.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, Type, cast
 import warnings
 
 import numpy as np
-from qiskit import QuantumCircuit, transpile
+from qiskit import transpile
 from qiskit.quantum_info import random_clifford, random_pauli
 from qiskit_aer import Aer
 from scipy.spatial.distance import hamming
@@ -35,6 +35,7 @@ from iqm.benchmarks.utils import (
     timeit,
     xrvariable_to_counts,
 )
+from iqm.qiskit_iqm import IQMCircuit as QuantumCircuit
 from iqm.qiskit_iqm.iqm_backend import IQMBackendBase
 
 

--- a/src/iqm/benchmarks/randomized_benchmarking/mirror_rb/mirror_rb.py
+++ b/src/iqm/benchmarks/randomized_benchmarking/mirror_rb/mirror_rb.py
@@ -611,25 +611,6 @@ class MirrorRandomizedBenchmarking(Benchmark):
                 dataset.attrs[key] = value
         # Defined outside configuration - if any
 
-    @timeit
-    def add_all_circuits_to_dataset(self, dataset: xr.Dataset):
-        """Adds all generated circuits during execution to the dataset variable
-        Args:
-            dataset (xr.Dataset):  The xarray dataset
-        """
-        qcvv_logger.info(f"Adding all circuits to the dataset")
-        dataset.attrs['transpiled_circuits'] = self.transpiled_circuits
-        dataset.attrs['untranspiled_circuits'] = self.untranspiled_circuits
-        # for key, circuit in zip(
-        #     ["transpiled_circuits", "untranspiled_circuits"], [self.transpiled_circuits, self.untranspiled_circuits]
-        # ):
-        #     dictionary = {}
-        #     for outer_key, outer_value in circuit.items():
-        #         dictionary[str(outer_key)] = {
-        #             str(inner_key): inner_values for inner_key, inner_values in outer_value.items()
-        #         }
-        #     dataset.attrs[key] = dictionary
-
     def submit_single_mrb_job(
         self,
         backend_arg: IQMBackendBase,
@@ -679,8 +660,6 @@ class MirrorRandomizedBenchmarking(Benchmark):
         # Initialize the variable to contain the circuits for each layout
         self.untranspiled_circuits = BenchmarkCircuit("untranspiled_circuits")
         self.transpiled_circuits = BenchmarkCircuit("transpiled_circuits")
-        # self.untranspiled_circuits: Dict[str, Dict[int | str, List[QuantumCircuit]]] = {}
-        # self.transpiled_circuits: Dict[str, Dict[int | str, List[QuantumCircuit]]] = {}
 
         # The depths should be assigned to each set of qubits!
         # The real final MRB depths are twice the originally specified, must be taken into account here!
@@ -704,8 +683,6 @@ class MirrorRandomizedBenchmarking(Benchmark):
         qubit_idx: Dict[str, Any] = {}
         for qubits_idx, qubits in enumerate(self.qubits_array):
             qubit_idx[str(qubits)] = qubits_idx
-            # self.untranspiled_circuits[str(qubits)] = {}
-            # self.transpiled_circuits[str(qubits)] = {}
 
             qcvv_logger.info(
                 f"Executing MRB on qubits {qubits}."
@@ -745,27 +722,11 @@ class MirrorRandomizedBenchmarking(Benchmark):
                 qcvv_logger.info(f"Job for layout {qubits} & depth {depth} submitted successfully!")
 
                 self.untranspiled_circuits.circuit_groups.append(
-                    CircuitGroup(
-                        name = f"{str(qubits)}_depth_{depth}",
-                        circuits=mrb_untranspiled_circuits_lists[depth]
-
-                    )
-
+                    CircuitGroup(name=f"{str(qubits)}_depth_{depth}", circuits=mrb_untranspiled_circuits_lists[depth])
                 )
                 self.transpiled_circuits.circuit_groups.append(
-                    CircuitGroup(
-                        name = f"{str(qubits)}_depth_{depth}",
-                        circuits=mrb_transpiled_circuits_lists[depth]
-
-                    )
-
-            )
-            # self.untranspiled_circuits[str(qubits)] = {
-            #     str(d): mrb_untranspiled_circuits_lists[d] for d in assigned_mrb_depths[str(qubits)]
-            # }
-            # self.transpiled_circuits[str(qubits)] = {
-            #     str(d): mrb_transpiled_circuits_lists[d] for d in assigned_mrb_depths[str(qubits)]
-            # }
+                    CircuitGroup(name=f"{str(qubits)}_depth_{depth}", circuits=mrb_transpiled_circuits_lists[depth])
+                )
 
             dataset.attrs[qubits_idx] = {"qubits": qubits}
 
@@ -795,7 +756,6 @@ class MirrorRandomizedBenchmarking(Benchmark):
             qcvv_logger.info(f"Adding counts of qubits {qubits} and depth {depth} run to the dataset")
             dataset, _ = add_counts_to_dataset(execution_results, f"qubits_{str(qubits)}_depth_{str(depth)}", dataset)
 
-        # self.add_all_circuits_to_dataset(dataset)
         self.circuits = Circuits([self.transpiled_circuits, self.untranspiled_circuits])
 
         qcvv_logger.info(f"MRB experiment execution concluded !")

--- a/src/iqm/benchmarks/randomized_benchmarking/randomized_benchmarking_common.py
+++ b/src/iqm/benchmarks/randomized_benchmarking/randomized_benchmarking_common.py
@@ -29,13 +29,14 @@ from matplotlib.collections import PolyCollection
 from matplotlib.figure import Figure
 import matplotlib.pyplot as plt
 import numpy as np
-from qiskit import QuantumCircuit, transpile
+from qiskit import transpile
 from qiskit.quantum_info import Clifford
 import xarray as xr
 
 from iqm.benchmarks.logging_config import qcvv_logger
 from iqm.benchmarks.randomized_benchmarking.multi_lmfit import create_multi_dataset_params, multi_dataset_residual
 from iqm.benchmarks.utils import get_iqm_backend, marginal_distribution, submit_execute, timeit
+from iqm.qiskit_iqm import IQMCircuit as QuantumCircuit
 from iqm.qiskit_iqm import optimize_single_qubit_gates
 from iqm.qiskit_iqm.iqm_backend import IQMBackendBase
 

--- a/src/iqm/benchmarks/readout_mitigation.py
+++ b/src/iqm/benchmarks/readout_mitigation.py
@@ -25,10 +25,11 @@ from mthree.classes import QuasiCollection
 from mthree.exceptions import M3Error
 from mthree.mitigation import _job_thread
 from mthree.utils import final_measurement_mapping
-from qiskit import QuantumCircuit, transpile  # pylint: disable = no-name-in-module
+from qiskit import transpile  # pylint: disable = no-name-in-module
 from qiskit.providers import Backend, BackendV1, BackendV2
 
 from iqm.benchmarks.utils import get_iqm_backend, timeit
+from iqm.qiskit_iqm import IQMCircuit as QuantumCircuit
 from iqm.qiskit_iqm.iqm_backend import IQMBackendBase
 
 

--- a/src/iqm/benchmarks/utils.py
+++ b/src/iqm/benchmarks/utils.py
@@ -25,12 +25,13 @@ from typing import Any, Dict, Iterable, List, Literal, Optional, Sequence, Tuple
 from more_itertools import chunked
 from mthree.utils import final_measurement_mapping
 import numpy as np
-from qiskit import ClassicalRegister, QuantumCircuit, transpile
+from qiskit import ClassicalRegister, transpile
 from qiskit.converters import circuit_to_dag
 from qiskit.transpiler import CouplingMap
 import xarray as xr
 
 from iqm.benchmarks.logging_config import qcvv_logger
+from iqm.qiskit_iqm import IQMCircuit as QuantumCircuit
 from iqm.qiskit_iqm import transpile_to_IQM
 from iqm.qiskit_iqm.fake_backends.fake_adonis import IQMFakeAdonis
 from iqm.qiskit_iqm.fake_backends.fake_apollo import IQMFakeApollo

--- a/src/mGST/qiskit_interface.py
+++ b/src/mGST/qiskit_interface.py
@@ -5,10 +5,10 @@ Bridge between mGST and Qiskit
 import random
 
 import numpy as np
-from qiskit import QuantumCircuit
 from qiskit.circuit.library import IGate
 from qiskit.quantum_info import Operator
 
+from iqm.qiskit_iqm import IQMCircuit as QuantumCircuit
 from mGST import additional_fns, algorithm, low_level_jit
 from mGST.compatibility import arrays_to_pygsti_model
 from mGST.reporting.reporting import gauge_opt, quick_report

--- a/tests/test_ghz.py
+++ b/tests/test_ghz.py
@@ -13,14 +13,13 @@ class TestGHZ:
     def test_layouts(self):
         MINIMAL_GHZ = GHZConfiguration(
             state_generation_routine=f"tree",
-            custom_qubits_array=
-            [
-                [0,1],
-                  [0,1,3],
-                  [0,1,3,4],
-                  # [0,1,2,3,4],
-                  # [0,1,2,3,4,5],
-                  # [0,1,2,3,4,5,6],
+            custom_qubits_array=[
+                [0, 1],
+                [0, 1, 3],
+                [0, 1, 3, 4],
+                # [0,1,2,3,4],
+                # [0,1,2,3,4,5],
+                # [0,1,2,3,4,5,6],
             ],
             shots=3,
             qiskit_optim_level=3,
@@ -38,7 +37,7 @@ class TestGHZ:
         for gen_routine in [f"tree", f"naive", "log_depth"]:
             MINIMAL_GHZ = GHZConfiguration(
                 state_generation_routine=gen_routine,
-                custom_qubits_array=[[0,1,2,3]],
+                custom_qubits_array=[[0, 1, 2, 3]],
                 shots=3,
                 qiskit_optim_level=3,
                 optimize_sqg=True,
@@ -55,7 +54,7 @@ class TestGHZ:
         for fidelity_routine in [f"coherences", f"randomized_measurements"]:
             MINIMAL_GHZ = GHZConfiguration(
                 state_generation_routine=f"tree",
-                custom_qubits_array=[[0,1,2,3]],
+                custom_qubits_array=[[0, 1, 2, 3]],
                 shots=3,
                 qiskit_optim_level=3,
                 optimize_sqg=True,

--- a/tests/test_gst.py
+++ b/tests/test_gst.py
@@ -16,7 +16,7 @@ class TestGST:
             shots=10,
             rank=4,
             bootstrap_samples=2,
-            max_iterations=[1, 1]
+            max_iterations=[1, 1],
         )
         benchmark = CompressiveGST(backend, minimal_1Q_config)
         benchmark.run()
@@ -33,7 +33,7 @@ class TestGST:
             shots=10,
             rank=1,
             bootstrap_samples=0,
-            max_iterations=[1, 1]
+            max_iterations=[1, 1],
         )
         benchmark = CompressiveGST(backend, minimal_2Q_GST)
         benchmark.run()

--- a/tests/unit/test_benchmark_circuit.py
+++ b/tests/unit/test_benchmark_circuit.py
@@ -7,44 +7,31 @@ from iqm.qiskit_iqm.iqm_circuit import IQMCircuit
 
 
 def test_circuit_group():
-    qreg = QuantumRegister(
-        size=1,
-        name='test_register'
-    )
+    qreg = QuantumRegister(size=1, name='test_register')
     qc = IQMCircuit(
         qreg,
         name='test_circuit',
     )
-    circuit_group = CircuitGroup(
-        circuits=[qc]
-    )
+    circuit_group = CircuitGroup(circuits=[qc])
     circuit_group.add_circuit(qc)
     assert circuit_group.circuits == [qc, qc]
     assert circuit_group.qubits == set([Qubit(QuantumRegister(1, 'test_register'), 0)])
-    assert circuit_group.qubit_layouts == tuple([[Qubit(QuantumRegister(1, 'test_register'), 0)], [
-        Qubit(QuantumRegister(1, 'test_register'), 0)]])
+    assert circuit_group.qubit_layouts == tuple(
+        [[Qubit(QuantumRegister(1, 'test_register'), 0)], [Qubit(QuantumRegister(1, 'test_register'), 0)]]
+    )
     assert circuit_group.qubit_layouts_by_index == ([0], [0])
     assert circuit_group.circuit_names == ['test_circuit', 'test_circuit']
 
 
 def test_benchmark_circuit():
-    qreg = QuantumRegister(
-        size=1,
-        name='test_register'
-    )
+    qreg = QuantumRegister(size=1, name='test_register')
     qc = IQMCircuit(
         qreg,
         name='test_circuit',
     )
-    circuit_group = CircuitGroup(
-        name='circuit_group',
-        circuits=[qc]
-    )
+    circuit_group = CircuitGroup(name='circuit_group', circuits=[qc])
 
-    benchmark_circuit = BenchmarkCircuit(
-        name='test',
-        circuit_groups=[circuit_group]
-    )
+    benchmark_circuit = BenchmarkCircuit(name='test', circuit_groups=[circuit_group])
 
     # print(benchmark_circuit['circuit_group'].name)
     assert benchmark_circuit.circuit_groups == [circuit_group]
@@ -53,23 +40,15 @@ def test_benchmark_circuit():
     assert benchmark_circuit.qubit_layouts_by_index == {(0,)}
     assert benchmark_circuit.qubit_layouts == {(Qubit(QuantumRegister(1, name='test_register'), 0),)}
 
+
 def test_circuits():
-    qreg = QuantumRegister(
-        size=1,
-        name='test_register'
-    )
+    qreg = QuantumRegister(size=1, name='test_register')
     qc = IQMCircuit(
         qreg,
         name='test_circuit',
     )
-    circuit_group = CircuitGroup(
-        name='circuit_group',
-        circuits=[qc]
-    )
+    circuit_group = CircuitGroup(name='circuit_group', circuits=[qc])
 
-    benchmark_circuit = BenchmarkCircuit(
-        name='test',
-        circuit_groups=[circuit_group]
-    )
+    benchmark_circuit = BenchmarkCircuit(name='test', circuit_groups=[circuit_group])
     circuits = Circuits([benchmark_circuit])
     assert circuits['test'] == benchmark_circuit

--- a/tests/unit/test_benchmark_circuit.py
+++ b/tests/unit/test_benchmark_circuit.py
@@ -17,9 +17,9 @@ def test_circuit_group():
     assert circuit_group.circuits == [qc, qc]
     assert circuit_group.qubits == set([Qubit(QuantumRegister(1, 'test_register'), 0)])
     assert circuit_group.qubit_layouts == tuple(
-        [[Qubit(QuantumRegister(1, 'test_register'), 0)], [Qubit(QuantumRegister(1, 'test_register'), 0)]]
+        [(Qubit(QuantumRegister(1, 'test_register'), 0),), (Qubit(QuantumRegister(1, 'test_register'), 0),)]
     )
-    assert circuit_group.qubit_layouts_by_index == ([0], [0])
+    assert circuit_group.qubit_layouts_by_index == ((0,), (0,))
     assert circuit_group.circuit_names == ['test_circuit', 'test_circuit']
 
 
@@ -37,8 +37,8 @@ def test_benchmark_circuit():
     assert benchmark_circuit.circuit_groups == [circuit_group]
     assert benchmark_circuit['circuit_group'] == circuit_group
     assert benchmark_circuit.qubit_indices == set([0])
-    assert benchmark_circuit.qubit_layouts_by_index == {(0,)}
-    assert benchmark_circuit.qubit_layouts == {(Qubit(QuantumRegister(1, name='test_register'), 0),)}
+    assert benchmark_circuit.qubit_layouts_by_index == {((0,),)}
+    assert benchmark_circuit.qubit_layouts == {((Qubit(QuantumRegister(1, name='test_register'), 0),),)}
 
 
 def test_circuits():

--- a/tests/unit/test_benchmark_circuit.py
+++ b/tests/unit/test_benchmark_circuit.py
@@ -1,0 +1,75 @@
+import pytest
+from qiskit import QuantumRegister
+from qiskit.circuit.quantumcircuit import Qubit
+
+from iqm.benchmarks import BenchmarkCircuit, CircuitGroup, Circuits
+from iqm.qiskit_iqm.iqm_circuit import IQMCircuit
+
+
+def test_circuit_group():
+    qreg = QuantumRegister(
+        size=1,
+        name='test_register'
+    )
+    qc = IQMCircuit(
+        qreg,
+        name='test_circuit',
+    )
+    circuit_group = CircuitGroup(
+        circuits=[qc]
+    )
+    circuit_group.add_circuit(qc)
+    assert circuit_group.circuits == [qc, qc]
+    assert circuit_group.qubits == set([Qubit(QuantumRegister(1, 'test_register'), 0)])
+    assert circuit_group.qubit_layouts == tuple([[Qubit(QuantumRegister(1, 'test_register'), 0)], [
+        Qubit(QuantumRegister(1, 'test_register'), 0)]])
+    assert circuit_group.qubit_layouts_by_index == ([0], [0])
+    assert circuit_group.circuit_names == ['test_circuit', 'test_circuit']
+
+
+def test_benchmark_circuit():
+    qreg = QuantumRegister(
+        size=1,
+        name='test_register'
+    )
+    qc = IQMCircuit(
+        qreg,
+        name='test_circuit',
+    )
+    circuit_group = CircuitGroup(
+        name='circuit_group',
+        circuits=[qc]
+    )
+
+    benchmark_circuit = BenchmarkCircuit(
+        name='test',
+        circuit_groups=[circuit_group]
+    )
+
+    # print(benchmark_circuit['circuit_group'].name)
+    assert benchmark_circuit.circuit_groups == [circuit_group]
+    assert benchmark_circuit['circuit_group'] == circuit_group
+    assert benchmark_circuit.qubit_indices == set([0])
+    assert benchmark_circuit.qubit_layouts_by_index == {(0,)}
+    assert benchmark_circuit.qubit_layouts == {(Qubit(QuantumRegister(1, name='test_register'), 0),)}
+
+def test_circuits():
+    qreg = QuantumRegister(
+        size=1,
+        name='test_register'
+    )
+    qc = IQMCircuit(
+        qreg,
+        name='test_circuit',
+    )
+    circuit_group = CircuitGroup(
+        name='circuit_group',
+        circuits=[qc]
+    )
+
+    benchmark_circuit = BenchmarkCircuit(
+        name='test',
+        circuit_groups=[circuit_group]
+    )
+    circuits = Circuits([benchmark_circuit])
+    assert circuits['test'] == benchmark_circuit

--- a/tests/unit/test_benchmark_circuit.py
+++ b/tests/unit/test_benchmark_circuit.py
@@ -7,28 +7,30 @@ from iqm.qiskit_iqm.iqm_circuit import IQMCircuit
 
 
 def test_circuit_group():
-    qreg = QuantumRegister(size=1, name='test_register')
+    qreg = QuantumRegister(size=3, name='test_register')
     qc = IQMCircuit(
         qreg,
         name='test_circuit',
     )
+    qc.x(0)
     circuit_group = CircuitGroup(circuits=[qc])
     circuit_group.add_circuit(qc)
     assert circuit_group.circuits == [qc, qc]
-    assert circuit_group.qubits == set([Qubit(QuantumRegister(1, 'test_register'), 0)])
+    assert circuit_group.qubits == set([Qubit(QuantumRegister(3, 'test_register'), 0)])
     assert circuit_group.qubit_layouts == tuple(
-        [(Qubit(QuantumRegister(1, 'test_register'), 0),), (Qubit(QuantumRegister(1, 'test_register'), 0),)]
+        [(Qubit(QuantumRegister(3, 'test_register'), 0),), (Qubit(QuantumRegister(3, 'test_register'), 0),)]
     )
     assert circuit_group.qubit_layouts_by_index == ((0,), (0,))
     assert circuit_group.circuit_names == ['test_circuit', 'test_circuit']
 
 
 def test_benchmark_circuit():
-    qreg = QuantumRegister(size=1, name='test_register')
+    qreg = QuantumRegister(size=2, name='test_register')
     qc = IQMCircuit(
         qreg,
         name='test_circuit',
     )
+    qc.x(0)
     circuit_group = CircuitGroup(name='circuit_group', circuits=[qc])
 
     benchmark_circuit = BenchmarkCircuit(name='test', circuit_groups=[circuit_group])
@@ -38,7 +40,7 @@ def test_benchmark_circuit():
     assert benchmark_circuit['circuit_group'] == circuit_group
     assert benchmark_circuit.qubit_indices == set([0])
     assert benchmark_circuit.qubit_layouts_by_index == {((0,),)}
-    assert benchmark_circuit.qubit_layouts == {((Qubit(QuantumRegister(1, name='test_register'), 0),),)}
+    assert benchmark_circuit.qubit_layouts == {((Qubit(QuantumRegister(2, name='test_register'), 0),),)}
 
 
 def test_circuits():


### PR DESCRIPTION
This PR adds the following dataclasses
* `CircuitGroup`: A named container of batched `IQMCircuit` circuits that are related. For example, a circuit to generate an 5-state GHZ. Contains helper properties `qubits`, `qubit_layouts` and `qubit_layouts_by_index` to get all the qubits used its circuits, and all the qubit layouts as well.
* `BenchmarkCircuit`: A named container of several `CircuitGroup`. This can contain, for example, all circuit groups to generate the 3-qubit, 4-qubit and 5-qubit GHZ state in a 5 qubit processor. Similar to `CircuitGroup`, has extra properties to study the qubits and layouts of its nested children.
* Circuits: An arbitrary container of `BenchmarkCircuit`. 

This PR also modifies the GHZ benchmark to use the new containers.

```python
from iqm.qiskit_iqm import IQMCircuit as QuantumCircuit
from iqm.benchmarks.circuit_containers import Circuits, CircuitGroup, BenchmarkCircuit
qc_5 = QuantumCircuit(
    5,
    name="5-qubit circuit"
 )

qc_3 = QuantumCircuit(
   3,
   name="3-qubit circuit"
)

circuit_group_1 = CircuitGroup(
    name="5_qubit_group",
    circuits = [qc_5]
)

circuit_group_2 = CircuitGroup(
    name="3_qubit_group",
    circuits = [qc_3]
)

circuits = Circuits([
    BenchmarkCircuit(
        name="3_and_5_qubit_groups",
        circuit_groups=[circuit_group_1,circuit_group_2]
        )
    ])
```
```python
print(circuits.benchmark_circuits[0].qubit_layouts_by_index)
>> {(0, 1, 2), (0, 1, 2, 3, 4)}

print(circuits.benchmark_circuits[0].qubit_layouts)
>> {(Qubit(QuantumRegister(3, 'q'), 0),
  Qubit(QuantumRegister(3, 'q'), 1),
  Qubit(QuantumRegister(3, 'q'), 2)),
 (Qubit(QuantumRegister(5, 'q'), 0),
  Qubit(QuantumRegister(5, 'q'), 1),
  Qubit(QuantumRegister(5, 'q'), 2),
  Qubit(QuantumRegister(5, 'q'), 3),
  Qubit(QuantumRegister(5, 'q'), 4))}
  
print(circuits.benchmark_circuits[0].circuit_groups[0].qubit_layouts)
>> ((Qubit(QuantumRegister(5, 'q'), 0),
  Qubit(QuantumRegister(5, 'q'), 1),
  Qubit(QuantumRegister(5, 'q'), 2),
  Qubit(QuantumRegister(5, 'q'), 3),
  Qubit(QuantumRegister(5, 'q'), 4)),)
  
print(circuit_group_1.qubit_layouts_by_index)
>> ((0, 1, 2, 3, 4),)
```

One can also do nested search as when using a dictionary, and also do assignment (although nested assignment with missing keys is not currently supported)

```python
circuits.benchmark_circuits[0]['5_qubit_group']['5-qubit circuit'].name
>> '5-qubit circuit'
```
```python
circuits['3_and_5_qubit_groups']['3_qubit_group']['3-qubit circuit']
>>><iqm.qiskit_iqm.iqm_circuit.IQMCircuit at 0x7194a93eb190>
