### PR TITLE
Removed unnecessary GST imports in __init__.py file

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+
+Version 2.8
+===========
+* Fixed a bug where optional dependencies related to gst were imported with other benchmarks, leading to a ModuleNotFoundError.
+
 Version 2.7
 ===========
 * Fixed bugs in Qscore and enabled benchmark execution for pyrite.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,10 +57,9 @@ examples = [
 ]
 
 mgst = [
-    "cvxpy == 1.5.3",
-    "pygsti == 0.9.12.3",
-    "tqdm == 4.66.5",
     "numba == 0.60.0",
+    "pygsti[diamond_norm] == 0.9.12.3",
+    "tqdm == 4.66.5",
 ]
 
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ examples = [
 ]
 
 mgst = [
-#    "cvxpy == 1.5.3",
+    "cvxpy == 1.5.3",
     "pygsti == 0.9.12.3",
     "tqdm == 4.66.5",
     "numba == 0.60.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,8 +57,7 @@ examples = [
 ]
 
 mgst = [
-    "numpy < 2.0",
-    "cvxpy == 1.5.3",
+#    "cvxpy == 1.5.3",
     "pygsti == 0.9.12.3",
     "tqdm == 4.66.5",
     "numba == 0.60.0",

--- a/src/iqm/benchmarks/__init__.py
+++ b/src/iqm/benchmarks/__init__.py
@@ -36,7 +36,6 @@ from .randomized_benchmarking.interleaved_rb.interleaved_rb import (
 )
 from .randomized_benchmarking.mirror_rb.mirror_rb import MirrorRandomizedBenchmarking, MirrorRBConfiguration
 
-
 AVAILABLE_BENCHMARKS = {
     GHZBenchmark.name: GHZBenchmark,
     CLOPSBenchmark.name: CLOPSBenchmark,
@@ -45,6 +44,14 @@ AVAILABLE_BENCHMARKS = {
     InterleavedRandomizedBenchmarking.name: InterleavedRandomizedBenchmarking,
     MirrorRandomizedBenchmarking.name: MirrorRandomizedBenchmarking,
 }
+
+try:
+    # Requires dependencies from "project.optional-dependencies.mgst" section to be installed. See "pyproject.toml"
+    # file
+    from .compressive_gst.compressive_gst import CompressiveGST, GSTConfiguration
+    AVAILABLE_BENCHMARKS.update({GSTBenchmark.name: GSTBenchmark})
+except:
+    pass
 
 try:
     # Change here if project is renamed and does not equal the package name

--- a/src/iqm/benchmarks/__init__.py
+++ b/src/iqm/benchmarks/__init__.py
@@ -36,6 +36,7 @@ from .randomized_benchmarking.interleaved_rb.interleaved_rb import (
 )
 from .randomized_benchmarking.mirror_rb.mirror_rb import MirrorRandomizedBenchmarking, MirrorRBConfiguration
 
+
 AVAILABLE_BENCHMARKS = {
     GHZBenchmark.name: GHZBenchmark,
     CLOPSBenchmark.name: CLOPSBenchmark,

--- a/src/iqm/benchmarks/__init__.py
+++ b/src/iqm/benchmarks/__init__.py
@@ -26,7 +26,6 @@ from .benchmark_definition import (
     BenchmarkRunResult,
 )
 from .circuit_containers import BenchmarkCircuit, CircuitGroup, Circuits
-from .compressive_gst.compressive_gst import CompressiveGST, GSTConfiguration
 from .entanglement.ghz import GHZBenchmark, GHZConfiguration
 from .quantum_volume.clops import CLOPSBenchmark, CLOPSConfiguration
 from .quantum_volume.quantum_volume import QuantumVolumeBenchmark, QuantumVolumeConfiguration

--- a/src/iqm/benchmarks/__init__.py
+++ b/src/iqm/benchmarks/__init__.py
@@ -49,8 +49,8 @@ try:
     # Requires dependencies from "project.optional-dependencies.mgst" section to be installed. See "pyproject.toml"
     # file
     from .compressive_gst.compressive_gst import CompressiveGST, GSTConfiguration
-    AVAILABLE_BENCHMARKS.update({GSTBenchmark.name: GSTBenchmark})
-except:
+    AVAILABLE_BENCHMARKS.update({CompressiveGST.name: CompressiveGST})
+except ModuleNotFoundError:
     pass
 
 try:

--- a/src/iqm/benchmarks/__init__.py
+++ b/src/iqm/benchmarks/__init__.py
@@ -50,6 +50,7 @@ try:
     # Requires dependencies from "project.optional-dependencies.mgst" section to be installed. See "pyproject.toml"
     # file
     from .compressive_gst.compressive_gst import CompressiveGST, GSTConfiguration
+
     AVAILABLE_BENCHMARKS.update({CompressiveGST.name: CompressiveGST})
 except ModuleNotFoundError:
     pass

--- a/src/iqm/benchmarks/compressive_gst/compressive_gst.py
+++ b/src/iqm/benchmarks/compressive_gst/compressive_gst.py
@@ -58,6 +58,8 @@ class CompressiveGST(Benchmark):
 
     analysis_function = staticmethod(mgst_analysis)
 
+    name: str = "compressive_gst"
+
     def __init__(self, backend: IQMBackendBase, configuration: "GSTConfiguration"):
         """Construct the compressive_gst class.
 
@@ -101,10 +103,6 @@ class CompressiveGST(Benchmark):
         # Circuit format used by mGST
         self.J = np.empty((self.configuration.num_circuits, self.num_povm))
         self.bootstrap_results = List[Tuple[np.ndarray]]  # List of GST outcomes from bootstrapping
-
-    @staticmethod
-    def name() -> str:
-        return "compressive_GST"
 
     @timeit
     def generate_meas_circuits(self) -> None:
@@ -172,7 +170,7 @@ class CompressiveGST(Benchmark):
         # Adding configuration entries and class variables, prioritizing the latter in case of conflicts
         for key, value in (self.configuration.__dict__ | self.__dict__).items():
             if key == "benchmark":  # Avoid saving the class objects
-                dataset.attrs[key] = value.name()
+                dataset.attrs[key] = value.name
             elif key == "backend":
                 dataset.attrs[key] = value.name
             else:


### PR DESCRIPTION
Fixing a bug where optional GST packages were imported when using other benchmarks, leading to a ModuleNotFoundError. 