### PR TITLE
Report average native single-qubit gate fidelity in Clifford RB

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+Version 2.11
+============
+* Report average native single-qubit gate fidelity estimates in observations of 1Q Clifford RB and 1Q IRB, and display in plots of 1Q Clifford RB.
+
 Version 2.10
 ============
 * Fix docs publishing by CI.

--- a/src/iqm/benchmarks/randomized_benchmarking/clifford_rb/clifford_rb.py
+++ b/src/iqm/benchmarks/randomized_benchmarking/clifford_rb/clifford_rb.py
@@ -128,6 +128,12 @@ def clifford_rb_analysis(run: BenchmarkRunResult) -> BenchmarkAnalysisResult:
             "avg_gate_fidelity": {"value": fidelity.value, "uncertainty": fidelity.stderr},
         }
 
+        if len(qubits) == 1:
+            fidelity_native = rb_fit_results.params["fidelity_per_native_sqg"]
+            processed_results.update(
+                {"avg_native_gate_fidelity": {"value": fidelity_native.value, "uncertainty": fidelity_native.stderr}}
+            )
+
         dataset.attrs[qubits_idx].update(
             {
                 "decay_rate": {"value": popt["decay_rate"].value, "uncertainty": popt["decay_rate"].stderr},

--- a/src/iqm/benchmarks/randomized_benchmarking/interleaved_rb/interleaved_rb.py
+++ b/src/iqm/benchmarks/randomized_benchmarking/interleaved_rb/interleaved_rb.py
@@ -170,10 +170,21 @@ def interleaved_rb_analysis(run: BenchmarkRunResult) -> BenchmarkAnalysisResult:
                 "avg_gate_fidelity": {"value": fidelity.value, "uncertainty": fidelity.stderr},
             }
 
+            if len(qubits) == 1 and rb_type == "clifford":
+                fidelity_native = rb_fit_results.params["fidelity_per_native_sqg"]
+                processed_results[rb_type].update(
+                    {
+                        "avg_native_gate_fidelity": {
+                            "value": fidelity_native.value,
+                            "uncertainty": fidelity_native.stderr,
+                        }
+                    }
+                )
+
             observations.extend(
                 [
                     BenchmarkObservation(
-                        name=f"{key}_{rb_type}",
+                        name=f"{key}_{rb_type}" if "native" not in key else f"{key}",
                         identifier=BenchmarkObservationIdentifier(qubits),
                         value=values["value"],
                         uncertainty=values["uncertainty"],

--- a/src/iqm/benchmarks/randomized_benchmarking/interleaved_rb/interleaved_rb.py
+++ b/src/iqm/benchmarks/randomized_benchmarking/interleaved_rb/interleaved_rb.py
@@ -75,6 +75,11 @@ def interleaved_rb_analysis(run: BenchmarkRunResult) -> BenchmarkAnalysisResult:
 
     interleaved_gate = dataset.attrs["interleaved_gate"]
     interleaved_gate_parameters = dataset.attrs["interleaved_gate_params"]
+    if interleaved_gate_parameters is None:
+        interleaved_gate_string = f"{interleaved_gate}"
+    else:
+        params_string = str(tuple(f"{x:.2f}" for x in interleaved_gate_parameters))
+        interleaved_gate_string = f"{interleaved_gate}{params_string}"
 
     simultaneous_fit = dataset.attrs["simultaneous_fit"]
 
@@ -138,6 +143,7 @@ def interleaved_rb_analysis(run: BenchmarkRunResult) -> BenchmarkAnalysisResult:
             [list_of_fidelities_clifford, list_of_fidelities_interleaved],
             "interleaved",
             simultaneous_fit,
+            interleaved_gate_string,
         )
         rb_fit_results = lmfit_minimizer(fit_parameters, fit_data, sequence_lengths, exponential_rb)
 
@@ -180,6 +186,16 @@ def interleaved_rb_analysis(run: BenchmarkRunResult) -> BenchmarkAnalysisResult:
                         }
                     }
                 )
+            elif len(qubits) == 2 and rb_type == "clifford" and interleaved_gate_string == "CZGate":
+                fidelity_native_sqg = rb_fit_results.params["fidelity_per_native_sqg"]
+                processed_results[rb_type].update(
+                    {
+                        "avg_gate_fidelity_native_sqg": {
+                            "value": fidelity_native_sqg.value,
+                            "uncertainty": fidelity_native_sqg.stderr,
+                        }
+                    }
+                )
 
             observations.extend(
                 [
@@ -217,12 +233,6 @@ def interleaved_rb_analysis(run: BenchmarkRunResult) -> BenchmarkAnalysisResult:
         obs_dict.update({qubits_idx: processed_results})
 
         # Generate decay plots
-        if interleaved_gate_parameters is None:
-            interleaved_gate_string = f"{interleaved_gate}"
-        else:
-            params_string = str(tuple(f"{x:.2f}" for x in interleaved_gate_parameters))
-            interleaved_gate_string = f"{interleaved_gate}{params_string}"
-
         fig_name, fig = plot_rb_decay(
             "irb",
             [qubits],

--- a/src/iqm/benchmarks/randomized_benchmarking/interleaved_rb/interleaved_rb.py
+++ b/src/iqm/benchmarks/randomized_benchmarking/interleaved_rb/interleaved_rb.py
@@ -174,7 +174,7 @@ def interleaved_rb_analysis(run: BenchmarkRunResult) -> BenchmarkAnalysisResult:
                 fidelity_native = rb_fit_results.params["fidelity_per_native_sqg"]
                 processed_results[rb_type].update(
                     {
-                        "avg_native_gate_fidelity": {
+                        "avg_gate_fidelity_native": {
                             "value": fidelity_native.value,
                             "uncertainty": fidelity_native.stderr,
                         }

--- a/src/iqm/benchmarks/randomized_benchmarking/randomized_benchmarking_common.py
+++ b/src/iqm/benchmarks/randomized_benchmarking/randomized_benchmarking_common.py
@@ -148,23 +148,23 @@ def fit_decay_lmfit(
             constraints=None,
             simultaneously_fit_vars=simultaneous_fit_vars,
         )
-        params.add(f"p_rb", expr=f"1-depolarization_probability_{1}")
-        params.add(f"fidelity_per_clifford", expr=f"p_rb + (1 - p_rb) / (2**{n_qubits})")
-        params.add(f"p_irb", expr=f"1-depolarization_probability_{2}")
-        params.add(f"interleaved_fidelity", expr=f"p_irb / p_rb + (1 - p_irb / p_rb) / (2**{n_qubits})")
+        params.add(f"p_rb", expr=f"1.0 - depolarization_probability_{1}")
+        params.add(f"fidelity_per_clifford", expr=f"p_rb + (1.0 - p_rb) / (2.0**{n_qubits})")
+        params.add(f"p_irb", expr=f"1.0 - depolarization_probability_{2}")
+        params.add(f"interleaved_fidelity", expr=f"p_irb / p_rb + (1.0 - p_irb / p_rb) / (2.0**{n_qubits})")
         if n_qubits == 1:
             # The construction of the 1Q and 2Q Clifford gate dictionaries in "generate_2qubit_cliffords.ipynb"
             # is based on the reference below; thus the expected amount of 1.875 native gates per Clifford
             # Native gate set being {I, X(pi/2), X(pi), X(-pi/2), Y(pi/2), Y(pi), Y(-pi)} with X(a)=r(a,0), Y(a)=r(a,pi/2)
             # Ref: Barends et al., Nature 508, 500-503 (2014); Eq.(S3) of arXiv:1402.4848 [quant-ph]
             # For IRB it may be used as proxy to how well (or bad) the assumption of uniform fidelity in native sqg gates holds.
-            params.add("fidelity_per_native_sqg", expr=f"1 - (1 - fidelity_per_clifford)/1.875")
+            params.add("fidelity_per_native_sqg", expr=f"1.0 - (1.0 - fidelity_per_clifford)/1.875")
         elif n_qubits == 2 and interleaved_gate_str == "CZGate":
             # Here similarly, we may use Eq.(S8 - S11) of arXiv:1402.4848 [quant-ph]
-            params.add(f"fidelity_clifford_and_interleaved", expr=f"p_irb + (1 - p_irb) / (2**{n_qubits})")
+            params.add(f"fidelity_clifford_and_interleaved", expr=f"p_irb + (1.0 - p_irb) / (2.0 ** {n_qubits})")
             params.add(
                 "fidelity_per_native_sqg",
-                expr=f"(1.0/33.0)*(4.0 * fidelity_clifford_and_interleaved - 10.0 * interleaved_fidelity + 39)",
+                expr=f"(1.0 / 33.0) * (4.0 * fidelity_clifford_and_interleaved - 10.0 * interleaved_fidelity + 39.0)",
             )
 
     return fit_data, params

--- a/src/iqm/benchmarks/randomized_benchmarking/randomized_benchmarking_common.py
+++ b/src/iqm/benchmarks/randomized_benchmarking/randomized_benchmarking_common.py
@@ -809,7 +809,7 @@ def plot_rb_decay(
             elif key == "interleaved":
                 plot_label = fr"$\overline{{F}}_{{{interleaved_gate}}}$ = {100.0 * fidelity_value[key][str(qubits)]:.2f} +/- {100.0 * fidelity_stderr[key][str(qubits)]:.2f} (%)"
             else:  # if id is "clifford"
-                if len(qubits) == 1 and identifier is not "irb":
+                if len(qubits) == 1 and identifier != "irb":
                     plot_label = fr"$\overline{{F}}_{{native\_sqg}} \simeq$ {100.0 * fidelity_native1q_value[key][str(qubits)]:.2f} +/- {100.0 * fidelity_native1q_stderr[key][str(qubits)]:.2f} (%)"
                 else:
                     plot_label = fr"$\overline{{F}}_{{CRB}}$ = {100.0 * fidelity_value[key][str(qubits)]:.2f} +/- {100.0 * fidelity_stderr[key][str(qubits)]:.2f} (%)"

--- a/src/iqm/benchmarks/randomized_benchmarking/randomized_benchmarking_common.py
+++ b/src/iqm/benchmarks/randomized_benchmarking/randomized_benchmarking_common.py
@@ -809,7 +809,7 @@ def plot_rb_decay(
             elif key == "interleaved":
                 plot_label = fr"$\overline{{F}}_{{{interleaved_gate}}} ({qubits})$ = {100.0 * fidelity_value[key][str(qubits)]:.2f} +/- {100.0 * fidelity_stderr[key][str(qubits)]:.2f} (%)"
             else:  # if id is "clifford"
-                if len(qubits) == 1:
+                if len(qubits) == 1 and identifier is not "irb":
                     plot_label = fr"$\overline{{F}}_{{native\_sqg}} \simeq$ {100.0 * fidelity_native1q_value[key][str(qubits)]:.2f} +/- {100.0 * fidelity_native1q_stderr[key][str(qubits)]:.2f} (%)"
                 else:
                     plot_label = fr"$\overline{{F}}_{{CRB}}$ = {100.0 * fidelity_value[key][str(qubits)]:.2f} +/- {100.0 * fidelity_stderr[key][str(qubits)]:.2f} (%)"

--- a/src/iqm/benchmarks/randomized_benchmarking/randomized_benchmarking_common.py
+++ b/src/iqm/benchmarks/randomized_benchmarking/randomized_benchmarking_common.py
@@ -148,6 +148,13 @@ def fit_decay_lmfit(
         )
         params.add(f"p_rb", expr=f"1-depolarization_probability_{1}")
         params.add(f"fidelity_per_clifford", expr=f"p_rb + (1 - p_rb) / (2**{n_qubits})")
+        if n_qubits == 1:
+            # The construction of the 1Q and 2Q Clifford gate dictionaries in "generate_2qubit_cliffords.ipynb"
+            # is based on the reference below; thus the expected amount of 1.875 native gates per Clifford
+            # Native gate set being {I, X(pi/2), X(pi), X(-pi/2), Y(pi/2), Y(pi), Y(-pi)} with X(a)=r(a,0), Y(a)=r(a,pi/2)
+            # Ref: Barends et al., Nature 508, 500-503 (2014); Eq.(S3) of arXiv:1402.4848 [quant-ph]
+            # For IRB it may be used as proxy to how well (or bad) the assumption of uniform fidelity in native sqg gates holds.
+            params.add("fidelity_per_native_sqg", expr=f"1 - (1 - (p_rb + (1 - p_rb) / (2**{n_qubits})))/1.875")
         params.add(f"p_irb", expr=f"1-depolarization_probability_{2}")
         params.add(f"interleaved_fidelity", expr=f"p_irb / p_rb + (1 - p_irb / p_rb) / (2**{n_qubits})")
 

--- a/src/iqm/benchmarks/randomized_benchmarking/randomized_benchmarking_common.py
+++ b/src/iqm/benchmarks/randomized_benchmarking/randomized_benchmarking_common.py
@@ -807,7 +807,7 @@ def plot_rb_decay(
             if identifier == "mrb":
                 plot_label = fr"$\overline{{F}}_{{MRB}} (n={len(qubits)})$ = {100.0 * fidelity_value[key][str(qubits)]:.2f} +/- {100.0 * fidelity_stderr[key][str(qubits)]:.2f} (%)"
             elif key == "interleaved":
-                plot_label = fr"$\overline{{F}}_{{{interleaved_gate}}} ({qubits})$ = {100.0 * fidelity_value[key][str(qubits)]:.2f} +/- {100.0 * fidelity_stderr[key][str(qubits)]:.2f} (%)"
+                plot_label = fr"$\overline{{F}}_{{{interleaved_gate}}}$ = {100.0 * fidelity_value[key][str(qubits)]:.2f} +/- {100.0 * fidelity_stderr[key][str(qubits)]:.2f} (%)"
             else:  # if id is "clifford"
                 if len(qubits) == 1 and identifier is not "irb":
                     plot_label = fr"$\overline{{F}}_{{native\_sqg}} \simeq$ {100.0 * fidelity_native1q_value[key][str(qubits)]:.2f} +/- {100.0 * fidelity_native1q_stderr[key][str(qubits)]:.2f} (%)"


### PR DESCRIPTION
Report avg native sqg fidelity in Clifford RB: adds `avg_native_gate_fidelity` to observations during analysis and reports `F_{native_sqg}` in RB decay plots.

Native 1Q gate set being `{I, X(pi/2), X(pi), X(-pi/2), Y(pi/2), Y(pi), Y(-pi)}` with `X(a)=r(a,0)` and `Y(a)=r(a,pi/2)`.

**Clifford 1Q RB**:
The estimate of avg native sqg fidelity follows Eq.(S3) of [arXiv:1402.4848](https://arxiv.org/abs/1402.4848), justified by the construction of the sampled Clifford gates, generated by means of the [generate_2qubit_clifford](https://github.com/iqm-finland/iqm-benchmarks/blob/report_avg_fidelity_per_native_sqg/examples/generate_2qubit_cliffords.ipynb) notebook.

**Interleaved 2Q RB (with interleaved CZ gate)**
The estimate of avg native sqg fidelity follows Eq.(S8-S11) of [arXiv:1402.4848](https://arxiv.org/abs/1402.4848) (similarly justified by the construction of Clifford gates).