### PR TITLE
GST bootstrapping bugfix and Jupyter documentation update

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+Version 2.31
+============
+* Fixed a bug in the bootstrapping functionality of the GST benchmark and updated the Jupyter tutorial.
+
 Version 2.30
 ============
 * Updated CLOPS value and plot reporting, making explicit offline values, such as time spent in transpilation and in parameter assigning.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 
 Version 2.31
 ============
-* Fixed a bug in the bootstrapping functionality of the GST benchmark and updated the Jupyter tutorial.
+* Fixed a bug in the bootstrapping functionality of the GST benchmark and updated the respective Jupyter tutorial.
 
 Version 2.30
 ============

--- a/docs/examples/example_gst.ipynb
+++ b/docs/examples/example_gst.ipynb
@@ -14,15 +14,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
    "id": "4e1ee575-ddef-44da-8e43-bf305853f00b",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-11-05T13:36:54.548883Z",
-     "start_time": "2024-11-05T13:36:43.570266Z"
+     "end_time": "2025-04-01T14:06:38.533363Z",
+     "start_time": "2025-04-01T14:06:34.321927Z"
     }
    },
-   "outputs": [],
    "source": [
     "%load_ext autoreload\n",
     "from iqm.benchmarks.compressive_gst.compressive_gst import GSTConfiguration, CompressiveGST\n",
@@ -30,7 +28,9 @@
     "import json\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 1
   },
   {
    "cell_type": "markdown",
@@ -42,20 +42,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
    "id": "5dcbf36f",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-11-05T13:36:54.563630Z",
-     "start_time": "2024-11-05T13:36:54.556417Z"
+     "end_time": "2025-04-01T14:06:38.547960Z",
+     "start_time": "2025-04-01T14:06:38.544085Z"
     }
    },
-   "outputs": [],
    "source": [
     "#backend = \"IQMFakeAdonis\"\n",
     "backend = \"IQMFakeApollo\"\n",
     "#backend = \"garnet\""
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 2
   },
   {
    "cell_type": "markdown",
@@ -79,15 +79,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
    "id": "2f8dc7ad-1742-4f51-a81c-86d2dc446a17",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-11-05T13:36:59.690753Z",
-     "start_time": "2024-11-05T13:36:59.681396Z"
+     "end_time": "2025-04-01T14:06:38.745186Z",
+     "start_time": "2025-04-01T14:06:38.737486Z"
     }
    },
-   "outputs": [],
    "source": [
     "Minimal_1Q_GST = GSTConfiguration(\n",
     "    qubit_layouts=[[0]],\n",
@@ -101,12 +99,14 @@
     "Minimal_2Q_GST = GSTConfiguration(\n",
     "    qubit_layouts=[[0,1]],\n",
     "    gate_set=\"2QXYCZ\",\n",
-    "    num_circuits=300,\n",
+    "    num_circuits=1000,\n",
     "    shots=1000,\n",
-    "    rank=2,\n",
+    "    rank=16,\n",
     "    bootstrap_samples=0,\n",
     ")"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 3
   },
   {
    "cell_type": "markdown",
@@ -119,37 +119,75 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
    "id": "561789a5-201a-484b-9acc-ae6382b517aa",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-11-05T13:37:50.532700Z",
-     "start_time": "2024-11-05T13:37:02.990016Z"
+     "end_time": "2025-04-01T14:06:49.947620Z",
+     "start_time": "2025-04-01T14:06:41.926964Z"
     }
    },
+   "source": [
+    "benchmark = CompressiveGST(backend, Minimal_1Q_GST)\n",
+    "benchmark.run()\n",
+    "result = benchmark.analyze()"
+   ],
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-01-08 12:51:09,571 - iqm.benchmarks.logging_config - INFO - Now generating 50 random GST circuits...\n",
-      "2025-01-08 12:51:09,790 - iqm.benchmarks.logging_config - INFO - Will transpile all 50 circuits according to fixed physical layout\n",
-      "2025-01-08 12:51:09,790 - iqm.benchmarks.logging_config - INFO - Transpiling for backend IQMFakeApolloBackend with optimization level 0, sabre routing method all circuits\n",
-      "2025-01-08 12:51:10,779 - iqm.benchmarks.logging_config - INFO - Submitting batch with 50 circuits corresponding to qubits [0]\n",
-      "2025-01-08 12:51:10,790 - iqm.benchmarks.logging_config - INFO - Now executing the corresponding circuit batch\n",
-      "2025-01-08 12:51:10,871 - iqm.benchmarks.logging_config - INFO - Retrieving all counts\n",
-      "2025-01-08 12:51:12,191 - iqm.benchmarks.logging_config - INFO - Starting mGST optimization...\n",
-      " 39%|███████████████████████████████▌                                                 | 39/100 [00:32<00:50,  1.20it/s]\n",
-      "2025-01-08 12:51:44,621 - iqm.benchmarks.logging_config - INFO - Convergence criterion satisfied\n",
-      "2025-01-08 12:51:44,623 - iqm.benchmarks.logging_config - INFO - Final objective 7.53e-5 in time 32.43s\n"
+      "2025-04-01 16:06:42,999 - iqm.benchmarks.logging_config - INFO - Now generating 50 random GST circuits...\n",
+      "2025-04-01 16:06:43,430 - iqm.benchmarks.logging_config - INFO - Will transpile all 50 circuits according to fixed physical layout\n",
+      "2025-04-01 16:06:43,430 - iqm.benchmarks.logging_config - INFO - Transpiling for backend IQMFakeApolloBackend with optimization level 0, sabre routing method all circuits\n",
+      "2025-04-01 16:06:44,259 - iqm.benchmarks.logging_config - INFO - Submitting batch with 50 circuits corresponding to qubits [0]\n",
+      "2025-04-01 16:06:44,338 - iqm.benchmarks.logging_config - INFO - Now executing the corresponding circuit batch\n",
+      "2025-04-01 16:06:44,434 - iqm.benchmarks.logging_config - INFO - Retrieving all counts\n",
+      "2025-04-01 16:06:46,644 - iqm.benchmarks.logging_config - INFO - Starting mGST optimization...\n",
+      " 26%|██▌       | 64/250 [00:01<00:05, 36.20it/s]\n",
+      "2025-04-01 16:06:48,462 - iqm.benchmarks.logging_config - INFO - Convergence criterion satisfied\n",
+      "2025-04-01 16:06:48,462 - iqm.benchmarks.logging_config - INFO - Final objective 1.56e-4 in time 1.82s\n"
      ]
     }
    ],
+   "execution_count": 4
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
    "source": [
-    "benchmark = CompressiveGST(backend, Minimal_1Q_GST)\n",
-    "benchmark.run()\n",
-    "result = benchmark.analyze()"
-   ]
+    "To get a unitary model of the gate set from the same data, the `rank` parameter of the benchmark object can be set to 1.\n",
+    "The analysis will give a Hamiltonian parametrization of the gate set and produce different plots."
+   ],
+   "id": "e682d8609d605b6b"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-01T14:07:57.113842Z",
+     "start_time": "2025-04-01T14:07:54.105844Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "from copy import deepcopy\n",
+    "benchmark_rK1 = deepcopy(benchmark)\n",
+    "benchmark_rK1.runs[0].dataset.attrs[\"rank\"] = 1\n",
+    "result_rK1 = benchmark_rK1.analyze()"
+   ],
+   "id": "8df941debc6577cb",
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-04-01 16:07:55,034 - iqm.benchmarks.logging_config - INFO - Starting mGST optimization...\n",
+      " 11%|█         | 27/250 [00:01<00:08, 24.83it/s]\n",
+      "2025-04-01 16:07:56,147 - iqm.benchmarks.logging_config - INFO - Convergence criterion satisfied\n",
+      "2025-04-01 16:07:56,148 - iqm.benchmarks.logging_config - INFO - Final objective 1.99e-4 in time 1.11s\n"
+     ]
+    }
+   ],
+   "execution_count": 6
   },
   {
    "cell_type": "markdown",
@@ -320,6 +358,47 @@
     "print(list(result.plots.keys()))\n",
     "result.plot('layout_[0]_gate_metrics')"
    ]
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "Rank 1 results (for example the gate Hamiltonians in the Pauli basis)",
+   "id": "de54a4b0fcd6ea3e"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-01T14:10:24.378858Z",
+     "start_time": "2025-04-01T14:10:24.304440Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "print(list(result_rK1.plots.keys()))\n",
+    "result_rK1.plot('layout_[0]_hamiltonian_parameters')"
+   ],
+   "id": "c7caa623df854825",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['layout_[0]_hamiltonian_parameters', 'layout_[0]_gate_metrics', 'layout_[0]_other_metrics', 'layout_[0]_process_matrix_0', 'layout_[0]_process_matrix_1', 'layout_[0]_process_matrix_2', 'layout_[0]_SPAM_matrices_real', 'layout_[0]_SPAM_matrices_imag']\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 1000x137.143 with 1 Axes>"
+      ],
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA5gAAAB9CAYAAADHqcwRAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAARJ1JREFUeJzt3XlcE9f6P/BPEsjCJrKDImpERVxQCy6tWCouV6m2X0WtomCtO2rvrRZta9FqXVsXKiK4i1ZtXWqttlftYq21WFFrF9wFN1QWBZUAQp7fH/yS65gACUYC5Hm/Xnlpzjxz5gyZZ2bOZDJHRERgjDHGGGOMMcaeldjcDWCMMcYYY4wxVjdwB5MxxhhjjDHGmElwB5MxxhhjjDHGmElwB5MxxhhjjDHGmElwB5MxxhhjjDHGmElwB5MxxhhjjDHGmElwB5MxxhhjjDHGmElYmbsBrGYTiUSNALiYux2MmZEUQLG5G8GYmXEeMMZ5wBgAZBPRtYoCuIPJyiUSiRqJROLzRGq5udvCmLmIRGIQqc3dDMbMivOAMc4DxgBAJBIXikSiFhV1MrmDySriQqSWvz5uFly9fMzdFsaq3cU/fsOPu9eCc4BZMs4DxjgPGAOArFsZ2JM4V46yuxu5g8mqztXLB56NW5i7GYxVu+xbGQA4B5hl4zxgjPOAMWPwQ34YY4wxxhhjjJkEdzAZY4wxxhhjjJkEdzAZM4Of9qzHnMhuKHhw39xNYaxa8bbPGOcBY5wDdRv/BpOxWuynPetx5KsNmL5yH2zsHc3dHMaqBRFh4/xoZGdmYNLCrbCxqyeY/s3GT3D6528wJnYNPHx8zdRKxp6f0pISJMWOxuOiQkyYvxnWUplg+v2sTMS/NwLN23VBePRcM7WSsefrflYmVkwbXGncgLdmIqBb32poEdPgDiZjjLFaRSQSISxqGlbPehOHtsVjwJj3tNOuX/oLqT99jS69h3DnktVZEisrhI2ajvXzJuLnvRvRI3ycYPqB5GWQWFmjT8RUM7WQsefPxsERr4/9QO80Nalx8POVKC5SwcOneTW3jHEHkzHGWK3j2qAJuvZ9A7/sS0a7bv9C45btUVpSgm82LEE9Jze8/H9vmruJjD1X3s1a44WQAfj12+1o06UX3Bo2AQD88/tPuPjHcfQd+R/YO7qYuZWMPT9SmQJtX+ytd9oPO9dA9Sgfvd6YBI9Gzaq5ZYw7mIyZUWHBQxzcHo9zp34BiODXMRh9R/4H1jK5uZvG2HNlim2/e/9I/J3yA77Z+AkmzNuI49/twN0bVzD07YWQyhTPsfWMmcaz5kGP8HE4d+oo9m/6BFHvrcTjIhX++/lnaNisNV545bXn23jGTOB5nAdd+fskfvlmC3zbdUbn3kNM2FpmKH7ID2Nm9GX8hyguVKHHoLFoFRSCM798i5++2mDuZjH23Jli27eSytBv5H+Qk3kN+zd9iiN7N6Jlx2C0aP/ic2o1Y6b1rHkgt7HDvyKm4tqFszh1ZB9+2LUWD/Ny8eqo6RCJRM+x5YyZhqnPgx7m5WJ34lzY1XPCa2Pe5zwwE/4GkzEz8vBpjgGjZ2jfqx7m4/TP+9FzyAQztoqx589U276yTRBadw7F6Z/3Qyq3wb/4N2esFjFFHrQKDEHzgK44tCMBxYUqvNj3Dbg1bPo8msuYyZnyPIjUauxJnIeC/PsYGbOcH35oRvwNJmNm9ELIAMH7Rs3bQvUwD0WqR2ZqEWPVw5Tbvo192VNkXRs0hoOTm0nax1h1MFUe9B35H5SWPEY9JzcED4gyYQsZe75MeSz4Zf8WXPn7d3TrPwKN/dqbqomsCriDyZgZ1XN2F7xX2NoDAFSPHpijOYxVG1Nt+7eunsPvh/fArWFT3Lz8D84e+6/J2sjY82aqPKjn7A5bh/pwbdBYZ8gSxmoyU+XAtQtn8dOe9WjUvB26vzbKZO1jVcMdTMbMSCwuJwWJqrchjFUzU2z7anUp9m1YDPv6Lnjzg1VooGyFg9vjUcgXaFgtwccAZulMkQOqh/nYlTAHMrktBk74EGKxxEStY1XFHUzGGGO1UsrBnbidcRH/ipgKmcIWYZHTUPAwH4e/TDR30xhjjFWTr9bMR37uXQx4ayb/TKKG4A4mY4yxWicv5w5+2rMOLdq/hJYdgwEAHj6+6NRzIE79tA83Lv9t5hYyxhh73n777xe4cOYYgnoORIsOL5m7Oez/46fIMsYYq3W+3bIcRMC/RrwtKH/59dH4+8SP2L/xU4yZs4ZvlWKMsTrqzrVLOPzFakjlCrh7Nyv3N/ju3kq4N2pWza2zbNzBZIwxVqucS/0Z50/9gp5DJ+k8IEKmsEGf4VPw5cpZSDm4E1368CDbjDFWF2VmXEBpyWOUljzGvvWLyo3r/too7mBWMxHxD8lZOUQiUQcAqWPnrIVn4xbmbg5j1e7PXw9id+JccA4wS8Z5wBjnAWMAkJl+HkmxbwFARyI6VV4c/waTMcYYY4wxxphJ8C2yjNVAhQUPUVJcVGGMnaNzNbWGserD2z5jnAeMcQ7UbtzBZKwG+m7rCvzxy3cVxsRuOlpNrWGs+vC2zxjnAWOcA7UbdzAZq4Fe7DsMbbv2NnczGKt2vO0zxnnAGOdA7cYdTMZqINcGTeDaoIm5m8FYteNtnzHOA8Y4B2o3fsgPY4wxxhhjjDGTMPgbTJFI1AiAy3NsC6t5WgLAxT9+Q/atDHO3hbFqd+3CnwA4B5hl4zxgjPOAMQC4l5VpUJxB42CKRKJGYrH4vFqtlj9rw1jtIhaLoVarzd0MxsyGc4AxzgPGAM4DxgBtHnQhot/KizH0G0wXtVot37JlC/z8/EzUPFbTHThwALNmzQJ/7sxScQ4wxnnAGMB5wBgApKWlISIiAgCKK4oz6iE/fn5+6NChw7O0i9UiaWlpAPhzZ5aLc4AxzgPGAM4DxozBD/lhjDHGGGOMMWYS3MFkjDHGGGOMMWYSNaaDGRUVhcaNGwvKRCIRZs+ebZb2MMYYY4wxxhgzznPvYG7cuBEikQgnT5583osy2N9//42IiAg0aNAAMpkMXl5eiIiIwD///KMTq2n/ky83NzeEhITg22+/1YnfsWMHIiIi4OvrC5FIhJdffrka1og9T0VFRYiJiYGXlxcUCgU6deqEQ4cOGTTvzZs3MXjwYDg6OsLBwQEDBgzAlStX9MauW7cOfn5+kMvl8PX1xWeffVYj62SW7f79+xg7dixcXV1ha2uLkJAQnDp1yuD509LS0KdPH9jZ2cHJyQkjRoxAVlaWTpxarcbixYvRpEkTyOVytG3bFtu2bdOJO3HiBCZOnIiOHTvC2toaIpGo3GXn5eXh3Xffha+vLxQKBXx8fDB69Ghcu3ZNb/yOHTvQpUsX2NrawtHREV27dsUPP/xg8LqyuqWmHQu2b9+ODh06QC6Xw9XVFaNHj0Z2drYgRqVSYfTo0WjdujXq1asHOzs7tGvXDitWrMDjx4/11nv48GG88sorqFevHuzt7dGxY0fs2LHDoPVkdV9NywPA8H01nxNVIyKq9AWgAwBKTU0lY23YsIEA0O+//15hXGRkJPn4+AjKAFBsbKzRy6zIrl27SCqVkoeHB73//vu0du1a+uCDD8jT05NkMhl99dVXetv/0UcfUXJyMm3evJmWLFlC/v7+BID27dsniO/evTvZ2dlRSEgI1a9fn7p3727S9lenLVu2UFU/97pk6NChZGVlRdOmTaPExETq0qULWVlZ0dGjRyuc78GDB+Tr60tubm60aNEiWrp0KXl7e1PDhg0pOztbELt69WoCQAMHDqSkpCQaMWIEAaCFCxfWqDotDeeAUGlpKXXt2pVsbW1p9uzZtHLlSmrVqhXZ29vThQsXKp3/+vXr5OLiQkqlklasWEEff/wx1a9fn9q1a0dFRUWC2BkzZhAAGjNmDCUlJVG/fv0IAG3btk0QFxsbS9bW1tSxY0dq3rw5lR3W9Lc9MDCQbG1tafr06bRmzRqKiYkhe3t7atCgAeXn5+vUKxKJKDw8nFavXk2fffYZjRs3jjZv3mzkX6324zwoU5OOBatWrSIA1KNHD4qPj6eZM2eSjY0NtW3bllQqlTYuJyeHOnXqRNOnT6f4+HhKSEigESNGkEgkojfeeEOnrevXryeRSES9evWilStXUkJCAr399tu0ZMmSZ/jL1Q2cB2VqUh4QGb6v5nMi00hNTSUABKADVdR3rGgi1bEO5qVLl8jGxoZatmxJd+/eFUzLysqili1bkp2dHV25ckVbXl77c3NzydramoYNGyYov3btGpWWlhIRkb+/P3cwa7mUlBQCIDi4qlQqUiqV1KVLlwrnXbRoEQGgEydOaMvS0tJIIpHQzJkztWUFBQXk7OxM/fr1E8w/fPhwsrW1pdzc3BpRpyXiHBDasWMHAaAvv/xSW3b37l1ydHTUe7L6tAkTJpBCoaCMjAxt2aFDhwgAJSYmastu3LhB1tbWNGnSJG2ZWq2mbt26UcOGDamkpERbfvv2bSooKCAiokmTJpXbwTx27BgBoJUrVwrK169fTwBo9+7d2rLjx4+TSCSipUuXVrpOloDzoGYdC4qKisjR0ZGCg4NJrVZr4/bt20cAKC4urtL1iY6OJgCUmZmpLbt69SopFAqaMmVKpfNbIs6DmpUHRIbvq/mcyHQM7WCa5TeYX331FVq3bg25XI7WrVtjz549Bs978+ZNvPnmm3B3d4dMJoO/vz/Wr1+vE3ft2jWcO3dOULZkyRIUFBQgKSkJrq6ugmkuLi5ITEzEw4cPsWTJkkrb4ejoCIVCASsr4Ugv3t7eEItrzE9b2TPauXMnJBIJxo4dqy2Ty+UYPXo0jh8/juvXr1c4b2BgIAIDA7VlLVu2RI8ePfDFF19oy3788Ufk5ORg4sSJgvknTZqER48eYf/+/TWiTsZ27twJd3d3/N///Z+2zNXVFYMHD8bevXtRVFRU4fy7du1CWFgYGjVqpC0LDQ1F8+bNBdva3r178fjxY8H2KxKJMGHCBNy4cQPHjx/Xlru7u0OhUFTa9vz8fG38kzw9PQFAUMfy5cvh4eGBqVOngojw8OHDSutndVtNOhb89ddfuH//PoYMGSK4JTwsLAx2dnbYvn17peujeebF/fv3tWWrV69GaWkpPvroIwDAw4cPNV8yMAagZuUBYPi+ms+Jql+194QOHjyIgQMHQiQSYcGCBXjttdcwatQog36jeefOHXTu3BmHDx9GdHQ0VqxYgWbNmmH06NFYvny5IHbkyJE6A+Hu27cPjRs3Rrdu3fTWHxwcjMaNG2Pfvn060/Ly8pCdnY2srCz8/fffmDBhAh4+fKgZbJTVUadPn0bz5s3h4OAgKA8KCgIAnDlzRu98arUaZ8+exQsvvKAzLSgoCJcvX8aDBw+0ywCgE9uxY0eIxWLtdHPXydjp06fRoUMHnYtoQUFBKCgowIULF8qd9+bNm7h7926525pmm9Qsx9bWVmcfrsm7J2MN9cILL8DW1hazZs3CDz/8gJs3b+LIkSN49913ERgYiNDQUG3s999/j8DAQMTFxcHV1RX29vbw9PTEypUrjV4uqxtq0rFAcyFH34UVhUKB06dPQ61WC8qLi4uRnZ2N69evY8+ePfjkk0/g4+ODZs2aaWMOHz6Mli1b4sCBA2jYsCHs7e3h7OyMWbNm6dTHLFNNygPA8H01nxNVP6vKQ0wrJiYG7u7u+OWXX1CvXj0AQPfu3dGrVy/4+PhUOO/777+P0tJS/Pnnn3B2dgYAjB8/Hm+88QZmz56NcePGlXslOy8vD7du3cKAAQMqXEbbtm3x9ddf48GDB7C3t9eWP3nyAQAymQzr169Hz549K11nVntlZmZqv+F4kqbs1q1beufLzc1FUVFRpfO2aNECmZmZkEgkcHNzE8RJpVI4Oztrl2HuOhnLzMxEcHCwTvmT20qbNm3KnffJ2Kfn12yLMpkMmZmZcHd313lgT2V5VxEXFxfs2LEDY8aMQY8ePbTlvXv3xs6dO7V3o9y7dw/Z2dk4duwYfvjhB8TGxqJRo0bYsGEDJk+eDGtra4wbN87o5bParSYdCzQPETx27BhGjRqljTt//rz2gVn37t3TnicBwO7du/HGG29o37/wwgtYv3694C6sixcvQiKRYNSoUXj33XfRrl077N69G/PmzUNJSQkWLFhQ8R+J1Xk1KQ+M2VfzOVH1q9YOZmZmJs6cOYMZM2ZoO5cA0LNnT7Rq1QqPHj0qd14iwq5duzB48GAQkeBJab1798b27dtx6tQpvPjiiwCAn376STC/5orDk51GfTTTn+5gxsfHo3nz5gDKvkndsmUL3nrrLdjb2wtuF2N1i0qlgkwm0ymXy+Xa6eXNB8CgeVUqFaRSqd565HK5IM6cdTJW1Xx4clpl88tksmdaTkVcXV3Rvn17REdHw9/fH2fOnMHixYsxatQofPnllwCgvcUqJycH27dvx5AhQwAAgwYNQps2bTBv3jzuYFqgmnQscHFxweDBg7Fp0yb4+fnh9ddfx82bN7Un1Y8fP9ZpT0hICA4dOoT79+/j+++/xx9//KFzzvXw4UOo1WosXLgQMTExAICBAwciNzcXK1aswHvvvVfpORSr22pSHhizr+ZzoupXrbfIZmRkACi7+va0yq4GZGVl4f79+9rfTz750lzBu3v3brnzP9lxrMiDBw8gEong4uIiKA8KCkJoaChCQ0MxfPhw7N+/H61atUJ0dDSKi4srrJPVXgqFQu/vygoLC7XTy5sPgEHzKhSKcrehwsJCQZw562SWo7i4GLdv3xa8SktLq5wPT04zdPs19TZ55coVhISE4M0338R7772HAQMGIDY2FqtWrcLOnTu1w05p6ra2tsagQYO084vFYgwZMgQ3btwod1gTVnfVpGMBACQmJqJv376YNm0alEolgoOD0aZNG7z66qsAADs7O8H87u7uCA0NxaBBg5CQkICwsDD07NkTt2/f1mnrk990at6rVKoq3ZrO6paalAfG7Kv5nKj61Zqn0Wju/4+IiMChQ4f0vjTfXupTr149eHl54ezZsxUu5+zZs2jYsGG5Vzo0xGIxQkJCkJmZiYsXLxq/QqxW8PT01N7a9yRNmZeXl975nJyctLf6VTavp6cnSktLdS6QFBcXIycnRxtn7jqZ5fj111/h6ekpeF2/fr3K+QD87/ai8ubXbIua2Nu3b+s8YORZtsmNGzeisLAQYWFhgvL+/fsDAI4dOwagLCfkcjmcnZ0hkUgEsZrbq+7du2f08lntVpOOBUDZOc3evXuRkZGBI0eOID09HcnJycjMzISrqyscHR0rXJ9Bgwbh4cOH2Lt3r7ZMU//TD8Li7Z5p1KQ8MGZfzedE1a9aO5ia31jq65CdP3++wnk1P94tLS3VfpP49Ovpe6uf9uqrr+Lq1av45Zdf9E4/evQo0tPTER4ebtD6lJSUAAA/YbAOCwgIwIULF7RPoNRISUnRTtdHLBajTZs2eh9elZKSgqZNm2q/VdfU8XTsyZMnoVartdPNXSezHO3atdO5gOfh4YGAgACcOnVK54EfKSkpsLGx0f6MQJ8GDRrA1dVV77Z24sQJQS4FBASgoKAAaWlpOsvRTDfWnTt3QEQoLS0VlGsGm9fsz8ViMQICApCVlaVzxVvzO52nn0LO6r6adCx4UqNGjRAcHAwfHx/cv38fqampOs+M0Edzm19eXp62rGPHjgDKHsj1JN7umUZNygNj9tV8TmQGFY1hQs9hHMyAgADy9PSk+/fva2MOHjxIACodBzMqKoqkUin9+eefOst5elzLjIwMSktLE5RdvHiRbGxsqFWrVjqDpebk5FCrVq3IwcHBoHEwi4uLydfXl6RSKeXl5elddx4Hs/b77bffdMZ8KiwspGbNmlGnTp20Zfq2t4ULF+psO+fOnSOJREIxMTHasoKCAnJycqKwsDDB/BEREWRjY0M5OTk1ok5LxDkgtH37dp1xMLOyssjR0ZGGDBkiiL106RJdunRJUDZ+/HhSKBR07do1bdnhw4cJACUkJGjLrl+/Xu44mA0aNBCMg/mkisbB/OSTTwgAbdiwQVC+fPlyAkDbt2/Xli1btowAUFJSkrZMpVJR06ZNqVWrVnrrr8s4D2resUCf8ePHk1gsFozfl5WVJRgrU0MzDub333+vLduzZw8BoPfee09bVlpaSi+99BI5OTlRYWFhhcuv6zgPal4eGLqv5nMi0zF0HMxq72B+++23JBaLqXXr1rR06VL64IMPqF69euTv719pB/P27dvk4+NDNjY2NHXqVEpMTKQFCxZQeHg41a9fXzBv9+7d9Z5o7Ny5k6ytrcnT05M++OADWrduHc2aNYu8vLxIoVDQ3r179bb/o48+ouTkZEpOTqZPP/2UOnbsSABoxowZgvgjR47Q3Llzae7cueTm5kaNGzfWvj9y5IjRfz9z4p1pmfDwcLKysqLp06dTYmIide3alaysrASfp77tLT8/n5RKJbm5udHixYtp2bJl5O3tTV5eXjoXROLj4wkADRo0iNasWUMjR44kAPTxxx/XqDotDeeAUElJCXXu3Jns7Oxozpw5FB8fT/7+/mRvb0/nzp0TxPr4+Ojs069du0bOzs6kVCopLi6O5s+fT/Xr16c2bdronLxOnz6dANDYsWNpzZo11K9fPwJAW7duFcSlp6dr97GdOnUiANr3mzdv1sZlZ2eTh4cHSaVSmjJlCiUmJtK4ceNIIpGQv78/FRUVaWMLCgrI39+frK2tadq0aRQXF0eBgYEkkUjowIEDJvpr1h6cB2Vq0rFgwYIFNHz4cIqLi6NVq1ZRr169CADNmzdPELds2TJq0aIFxcTEUGJiIn3yySfUs2dPAkCvvvqqIFatVlOPHj1IJBLR2LFjKT4+XhubmJhoij9hrcZ5UKYm5YEx+2o+JzKNGtvBJCLatWsX+fn5kUwmo1atWtHu3bspMjKy0g4mEdGdO3do0qRJ5O3tTdbW1uTh4UE9evQQXL0gKr+DSUT0559/0rBhw8jDw4PEYjEBILlcTn///Xe57X/yJZfLKSAggBISEnSuDMbGxurEa15Pr0tNxzvTMiqViqZNm0YeHh4kk8koMDCQvvvuO0FMedvb9evXadCgQeTg4EB2dnYUFhZGFy9e1LucpKQkatGiBUmlUlIqlbRs2TK9V57NXacl4RzQlZubS6NHjyZnZ2eysbGh7t2769zhQaS/g0lE9Ndff1GvXr3IxsaGHB0dafjw4XT79m2duNLSUpo/fz75+PiQVColf39/2rJli07cjz/+WO4+9+k7SG7cuEFvvvkmNWnShKRSKXl6etKYMWMoKytLp947d+5QZGQkOTk5kUwmo06dOunkvaXgPChTk44F33zzDQUFBZG9vT3Z2NhQ586d6YsvvtCp6/fff6fw8HBq1KgRyWQysrW1pQ4dOtDSpUvp8ePHOvEPHjygqVOnai/GtGnTRm/eWSLOgzI1KQ+IjNtX8znRszO0gymipx6ioI9IJOoAIDU1NRUdOnSoNL622bx5M6KiohAREYHNmzebuzk1xtatWxEREYG6+rkzVhnOAcY4DxgDOA8YA4BTp05pfq/dkYhOlRdXreNg1lQjR45EZmYmZsyYgYYNG2L+/PnmbhJjjDHGGGOM1Trcwfz/YmJitAMLM8YYY4wxxhgzXq0ZB5MxxhhjjDHGWM3GHUzGGGOMMcYYYybBHUzGGGOMMcYYYyZh1G8wDxw4gLS0tOfVFlbDHDt2DAB/7sxycQ4wxnnAGMB5wBgAXL161aA4Q4cp6SwWi4+r1epnbRerZcRiMfhzZ5aMc4AxzgPGAM4DxgBtHnQhot/KizH0G8xitVqNLVu2wM/Pz0TNYzXdgQMHMGvWLP7cmcXiHGCM84AxgPOAMQBIS0tDREQEABRXFGfULbJ+fn48uKwF0dwCwp87s1ScA4xxHjAGcB4wZgx+yA9jjDHGGGOMMZPgDiZjjDHGGGOMMZOw+A6mSCTC7Nmzzd0MxhhjjDHGGKv1nnsHc+PGjRCJRNqXlZUVGjRogKioKNy8efN5L97kcnJysGTJEgQHB8PV1RWOjo7o3LkzduzYYXRd33zzDfr06QNnZ2fI5XI0b94c06dPR25urk5sVFSUzt/R29sbQ4cOxT///KMT//HHH6N///5wd3fnTvQzKioqQkxMDLy8vKBQKNCpUyccOnTIoHlv3ryJwYMHw9HREQ4ODhgwYACuXLmiN3bdunXw8/ODXC6Hr68vPvvssxpZJ7M8Vc2B2bNnC/ZbmpdcLtcbb64cMLadzDLV1mNBQkICwsPD0ahRI4hEIkRFRZXbztTUVISFhcHDwwN2dnZo27Yt4uLiUFpaatB6srqvtuaBoXWeP38e//73v9G1a1fI5XKIRCKkp6cbtH7sCURU6QtABwCUmppKxtqwYQMBoI8++oiSk5NpzZo1NHr0aJJIJKRUKkmlUhldpympVCp6/PixwfH79u0ja2trGjBgAC1fvpxWrlxJISEhBIA+/PBDg+t55513CAC1a9eOFi1aRGvWrKEJEyaQTCYjb29vunDhgiA+MjKSZDIZJScnU3JyMm3YsIE++OADcnFxoXr16tHNmzcF8QDIw8ODevfuTQAoNjbW4LZpbNmyhar6udclQ4cOJSsrK5o2bRolJiZSly5dyMrKio4ePVrhfA8ePCBfX19yc3OjRYsW0dKlS8nb25saNmxI2dnZgtjVq1cTABo4cCAlJSXRiBEjCAAtXLiwRtVpaTgHylQ1B2JjYwkAJSQkaPddycnJ9Pnnn+vEmjMHjGmnJeI8KFNbjwU+Pj7k5OREffr0ISsrK4qMjNTbzpMnT5JUKiV/f39aunQprV69mgYMGEAAaMqUKcb/weoYzoMytTUPDK1zw4YNJBaLqXXr1hQQEEAA6OrVq1X/g9UxqampBIAAdKCK+o4VTSQTdjB///13QXlMTAwBoB07dlR1Hc3iypUrlJ6eLihTq9X0yiuvkEwmo4cPH1Zax+eff04AaMiQIVRSUiKYlpKSQjY2NtSuXTtBxzcyMpJsbW116vrmm28IACUlJQnKNcmQlZXFHcxnkJKSQgBoyZIl2jKVSkVKpZK6dOlS4byLFi0iAHTixAltWVpaGkkkEpo5c6a2rKCggJydnalfv36C+YcPH062traUm5tbI+q0RJwDz5YDmo5bVlZWhXHmzgFD22mpOA9q77GAiCg9PZ3UajUREdna2pbbwRwzZgxJpVLKyckRlAcHB5ODg0OF62gJOA9qbx4YU2dOTg7l5+cTEdGSJUu4g/kUQzuYZvsNZrdu3QAAly9fBgD88MMPEIvF+PDDDwVxn3/+OUQiERISEgyuOyoqCnZ2drhy5Qp69+4NW1tbeHl54aOPPtJ0mLWMvX20SZMm8PHx0anjtddeQ1FRkc7X8ufOncO1a9cEZXPmzEH9+vWRlJQEiUQimBYUFISYmBj88ccf2L17d6Xt8fDwAABYWQlHnGncuLGhq8QqsHPnTkgkEowdO1ZbJpfLMXr0aBw/fhzXr1+vcN7AwEAEBgZqy1q2bIkePXrgiy++0Jb9+OOPyMnJwcSJEwXzT5o0CY8ePcL+/ftrRJ3MMj1LDmgQEfLz83X2vxrmzgFD28ksV209FgCAj48PRCJRpeuYn58PuVwOR0dHQbmnpycUCkWl87O6r7bmgTF1Ojk5wd7e3pA/B6uA2TqYmvuZ69evDwB45ZVXMHHiRCxYsACnTp0CAGRmZmLy5MkIDQ3F+PHjjaq/tLQUffr0gbu7OxYvXoyOHTsiNjYWsbGxJl0Pjdu3bwMAXFxcBOV+fn4YOXKk9v3Fixdx/vx5DBgwAA4ODnrr0sTv27dPZ1p2djays7Nx584dHD9+HP/+97/h7OyMsLAwU60Ke8Lp06fRvHlznc8qKCgIAHDmzBm986nVapw9exYvvPCCzrSgoCBcvnwZDx480C4DgE5sx44dIRaLtdPNXSezTFXNgSc1bdoU9erVg729PSIiInDnzh2dZQDmyQFj2sksV209Fhjj5ZdfRn5+PsaNG4e0tDRkZGRg9erV2L17N2bOnGl0fazuqa15UJXjAXs2VpWHmEZeXh6ys7NRWFiIlJQUzJkzBzKZTNAxWrx4Mf773/9i5MiRSE1NxZgxY1BSUoJ169YZdPXtSYWFhejTpw/i4uIAABMnTsSrr76KRYsWYcqUKTodwWeRm5uLtWvXolu3bvD09KwwVvNAnnbt2pUb07hxYzg4OOg8vOfRo0dwdXUVlDVo0AAHDx7UKWemkZmZqfcz1ZTdunVL73y5ubkoKiqqdN4WLVogMzMTEokEbm5ugjipVApnZ2ftMsxdJ7NMVc0BoOwCYnR0NLp06QKZTIajR48iPj4eJ06cwMmTJ7UnKebMAWPaySxXbT0WGGPMmDH4+++/kZiYiLVr1wIAJBIJVq5cafRFflY31dY8MOZ4wEyj2jqYoaGhgveNGzfGli1b0LBhQ22ZjY0NNm7ciODgYAQHB+PEiRNYt24dGjVqVKVlRkdHa/8vEokQHR2N/fv34/Dhwxg6dGjVVuQparUaw4cPx/379/U+jerpW600V1Mq+/rd3t5e5wqkXC7XfqupVquRnp6OpUuXom/fvvj555/RvHnzZ1kVpodKpYJMJtMp1zxdUqVSlTsfAIPmValUkEqleuuRy+WCOHPWySxTVXMAAKZOnSp4P3DgQAQFBWH48OFYtWoVZsyYoa3DXDlgTDuZ5aqtxwJjSCQSKJVK9O7dG+Hh4ZDL5di2bRsmT54MDw8PvPbaa0bXyeqW2poHxhwPmGlU2y2y8fHxOHToEHbu3Im+ffsiOztb70bx4osvYsKECThx4gR69+6NN998s0rLE4vFaNq0qaBM0wEz5eOGJ0+ejO+++w5r166t8FtJDU3HsrLbVx48eKBzpUUikSA0NBShoaHo1asXxo4di8OHDyMvL49vX3lOFAoFioqKdMoLCwu108ubD4BB8yoUChQXF+utp7CwUBBnzjqZZapqDpRn2LBh8PDwwOHDhwXLMFcOGNNOZrlq67HAGAsXLsSiRYuwbds2jBw5EoMHD8aePXvw0ksvYdKkSSgpKTG6Tla31NY8eNbjATNetXUwg4KCEBoaioEDB+Lrr79G69atMWzYMDx8+FAQV1RUhJ9++glA2QOACgoKqquJRpszZw5WrVqFhQsXYsSIEQbN06pVKwDA2bNny43JyMhAfn6+TgdZn4YNG6JFixb4+eefDWs0M4qnpycyMzN1yjVlXl5eeudzcnKCTCYzaF5PT0+Ulpbi7t27grji4mLk5ORo48xdJ7NMVc2Binh7ewvG+zVnDhjTTma5auuxwBirVq3CK6+8Ajs7O0F5//79cevWLR4LkNXaPDDF8YAZxywP+ZFIJFiwYAFu3bqFlStXCqbFxsYiLS0Nn3zyCa5evVrlW5PUarXOE10vXLgAwDRPWI2Pj8fs2bPx9ttvIyYmxuD5fH190aJFC3z11Vflfou5efNmAEB4eLhBdZaUlOh01JlpBAQE4MKFC8jPzxeUp6SkaKfrIxaL0aZNG5w8eVJnWkpKCpo2bar9NltTx9OxJ0+ehFqt1k43d53MMlU1B8pDREhPTxf8btycOWBMO5nlqq3HAmPcuXMHpaWlOuWPHz8GAP4Gk9XaPHjW4wGrgorGMKHnOA4mEVFQUBC5u7uTSqUiIqLffvuNJBIJ/ec//yEiohkzZpBIJKKffvrJqGVGRkYSAJo8ebK2TK1WU79+/cja2pru3r2rLUcVxojcvn07icViGj58uHZsqfKkpaVRRkaGoEwzDuawYcN0xsE8efIk2draUvv27Q0aB/P8+fNkZWVFnTp10rt8Hgfz2fz22286Yz4VFhZSs2bNBH/zjIwMSktLE8y7cOFCnW3/3LlzJJFIKCYmRltWUFBATk5OFBYWJpg/IiKCbGxsBGOSmbNOS8Q58Gw58OS+ViM+Pp4A0NKlS7Vl5s4BQ9tpqTgPau+x4GkVjYPZunVrcnJyEgxQX1JSQh07diR7e3sqLi4ut15LwHlQe/PAmDqfxONg6jJ0HEyzdjC//PJLAkAJCQmkUqmoRYsW1LJlS22Hs6ioiPz9/alJkyb08OFDg5cZGRlJcrmcfH19aeTIkRQfH09hYWEEgN577z1BrLGdr5SUFJJKpeTq6krr16+n5ORkwevy5cs69Xfv3l2nnv/85z8EgAICAmjJkiW0du1amjhxIsnlcvL29tapJzIykmQymXY5mzZtojlz5pCnpyeJxWI6cOCAIH7z5s00d+5cmjlzJgGgkJAQmjt3Ls2dO5fS09MNWlfemZYJDw8nKysrmj59OiUmJlLXrl3JysqKjhw5oo3p3r07lV2v+Z/8/HxSKpXk5uZGixcvpmXLlpG3tzd5eXnpnNBqTmYHDRpEa9asoZEjRxIA+vjjj2tUnZaGc6BMVXNAoVBQVFQUffrppxQfH09vvPEGiUQiCggIoEePHglizZkDxrTTEnEelKmtx4Kvv/5ae/yXSqXUvn177fs//vhDG6f5nJVKJS1atIji4uKoS5cuBIDmzZtnqj9jrcV5UKa25oGhdd6/f1+bH3369CEA9M4779DcuXPps88+M8WfsFarFR3M0tJSUiqVpFQq6e233yaJREIpKSmCmJMnT5KVlRVNmDDB4GVqvu27fPky9erVi2xsbMjd3Z1iY2OptLRUEGtsB1OzPuW9NmzYoFO/vg4mUdlOPzQ0lBwdHbXz+/v7U15ent51enpZDg4O1KNHDzp8+LBOvCa59b1+/PFHg9aVd6ZlVCoVTZs2jTw8PEgmk1FgYCB99913ghh9O1MiouvXr9OgQYPIwcGB7OzsKCwsjC5evKh3OUlJSdSiRQuSSqWkVCpp2bJler8hN3edloRzoExVc+Ctt96iVq1akb29PVlbW1OzZs0oJiaG8vPz9S7HXDlgbDstDedBmdp6LNB3/lDeOct3331H3bt3JxcXF5JKpdSmTRtavXq1EX+luovzoExtzQND67x69Wq5+eLj42PgX6nuMrSDKaKnhtHQRyQSdQCQmpqaig4dOlQab25RUVHYuXNnrftd4ltvvYV169ZhzZo1eOutt8zdHGzduhURERGoLZ87Y6bGOcAY5wFjAOcBYwBw6tQpdOzYEQA6EtGp8uKqbRxMVrnExETcuXMHEyZMgJeXF/r27WvuJjHGGGOMMcaYwWpVBzMvL6/SwVA9PDyqVHdpaSmysrIqjLGzs9N5fLcpSSQS7Nu377nVzxhjjDHGGGPPU63qYE6dOhWbNm2qMMaQW371uX79Opo0aVJhTGxsLGbPnl2l+hljjDHGGGOsrqtVHcx3330XERERlcZt3LgRGzduNKpuDw8PHDp0qMKYpk2bGlUnY4wxxhhjjFmSWtXBbNWqFVq1avVc6pbL5QgNDX0udTPGGGOMMcaYJRCbuwGMMcYYY4wxxuoGo77BPHDgANLS0p5XW1gNc+zYMQD8uTPLxTnAGOcBYwDnAWMAcPXqVYPiDB0Hs7NYLD6uVquftV2slhGLxeDPnVkyzgHGOA8YAzgPGAO0edCFiH4rL8bQbzCL1Wo1tmzZAj8/PxM1j9V0Bw4cwKxZs/hzZxaLc4AxzgPGAM4DxgAgLS1N88DV4orijLpF1s/PDx06dHiWdrFaRHMLCH/uzFJxDjDGecAYwHnAmDH4IT+MMcYYY4wxxkyCO5iMMcYYY4wxxkzCojuYjRs3RlRUlLmbwWqJ+/fvY+zYsXB1dYWtrS1CQkJw6tQpg+dPS0tDnz59YGdnBycnJ4wYMQJZWVk6cWq1GosXL0aTJk0gl8vRtm1bbNu2rcbVySxHUVERYmJi4OXlBYVCgU6dOuHQoUMGzXvz5k0MHjwYjo6OcHBwwIABA3DlyhW9sevWrYOfnx/kcjl8fX3x2WefPVOdCQkJCA8PR6NGjSASiSrc36empiIsLAweHh6ws7ND27ZtERcXh9LSUoPWk9V9z5IHT+rZsydEIhGio6N1pt25cwejRo2Cm5sbFAoFOnTogC+//FJvPdu3b0eHDh0gl8vh6uqK0aNHIzs7WycuLy8P7777Lnx9faFQKODj44PRo0fj2rVrVW4nY4BlnBdFRUVBJBLpvFq2bGnwelokIqr0BaADAEpNTSVjbdiwgQBoXxKJhLy8vCgyMpJu3LhhdH2m5OPjQ5GRkQbHP3r0iFauXEk9e/YkDw8PsrOzo4CAAFq1ahWVlJQYtexffvmFXnvtNXJzcyOpVEo+Pj40btw4unbtmk5sbGys4G8oEonIw8OD+vXrR8ePH9eJX7VqFQ0aNIi8vb0JgFHr+KQtW7ZQVT/3uqa0tJS6du1Ktra2NHv2bFq5ciW1atWK7O3t6cKFC5XOf/36dXJxcSGlUkkrVqygjz/+mOrXr0/t2rWjoqIiQeyMGTMIAI0ZM4aSkpKoX79+BIC2bdtWo+q0BJwDZYYOHUpWVlY0bdo0SkxMpC5dupCVlRUdPXq0wvkePHhAvr6+5ObmRosWLaKlS5eSt7c3NWzYkLKzswWxq1evJgA0cOBASkpKohEjRhAAWrhwYZXr9PHxIScnJ+rTpw9ZWVmVuy88efIkSaVS8vf3p6VLl9Lq1atpwIABBICmTJli/B+sjuE8KFPVPHjSrl27yNbWlgDQpEmTBNPy8vKoWbNmZG9vTx988AGtXLmSgoODCQBt3bpVELtq1SoCQD169KD4+HiaOXMm2djYUNu2bUmlUmnjSktLKTAwkGxtbWn69Om0Zs0aiomJIXt7e2rQoAHl5+cb3U5LxXkgZCnnRZGRkSSTySg5OVnw+vrrr6v4l6vdUlNTNf2RDlRR37GiiWTCDuZHH31EycnJtGbNGho9ejRJJBJSKpWCHWF1KywspOLiYoPj//zzTxKJRBQaGkqLFy+m1atX0+uvv04AaOTIkQbXExcXRyKRiJRKJc2dO5fWrl1L77zzDtWrV48cHR11Oo2aDmZCQgIlJyfTpk2baN68eeTj40PW1tZ0+vRpQbyhJ1WV4Z3p/+zYsYMA0Jdffqktu3v3Ljk6OtIbb7xR6fwTJkwghUJBGRkZ2rJDhw4RAEpMTNSW3bhxg6ytrQUHdLVaTd26daOGDRsKLmSYs05LwTlAlJKSQgBoyZIl2jKVSkVKpZK6dOlS4byLFi0iAHTixAltWVpaGkkkEpo5c6a2rKCggJydnalfv36C+YcPH062traUm5trdJ1EROnp6aRWq4mIyNbWttx94ZgxY0gqlVJOTo6gPDg4mBwcHCpcR0vAefBsefBkfOPGjemjjz7S23FbvHgxAaDvv/9eW6bpIHp4eGhPkIuKisjR0ZGCg4O12zcR0b59+wgAxcXFacuOHTtGAGjlypWCZa1fv54A0O7du41up6XiPBCylPOiyMhIsrW1NeRPYhFqXAfz999/F5THxMQQANqxY0dV17HaZWVl0V9//aVTPmrUKAJAFy9erLSOX375hcRiMXXr1o0ePXokmHbp0iVyd3cnLy8vunfvnrZc08HMysoSxP/1118EgN577z1BuaEnVZXhnen/hIeHk7u7O5WWlgrKx44dSzY2NlRYWFjh/G5ubhQeHq5T3rx5c+rRo4f2fXx8PAGgv//+WxD3+eefEwDBlXJz1mkpOAeIpk+fThKJhPLy8gTl8+fPJwB677rQCAwMpMDAQJ3yXr16kVKp1L7fv38/AaD9+/cL4n799VcCQMnJyUbX+bSK9oVDhgwhBwcHnfweMmQIubu7l1unpeA8eLY80JgzZw41atSICgoK9HbcXn31VXJ1ddWZb8mSJQSADh48SET/O8GLj4/XibWzs6OuXbtq33/77bc6nYAny7/99luj22mpOA+ELOW8SNPBLCkp0cl/S2RoB9Nsv8Hs1q0bAODy5cuIjY2FtbW13nukx44dC0dHRxQWFhpU7+zZsyESiXDu3DkMHjwYDg4OcHZ2xtSpU3XqMPY3mC4uLvD399cpf/311wH87xHWGpcvX8bly5cFZXPnzoVIJMKmTZtgY2MjmKZUKrF48WLcunULSUlJlbbHw8MDAGBlJRxtxsfHByKRqPIVYgY7ffo0OnToALFYmDJBQUEoKCjAhQsXyp335s2buHv3Ll544QWdaUFBQTh9+rRgOba2tjpjbAUFBWmn14Q6meU4ffo0mjdvDgcHB0G5Zvs5c+aM3vnUajXOnj1b7vZ0+fJlPHjwQLsMADqxHTt2hFgs1k43pk5jvPzyy8jPz8e4ceOQlpaGjIwMrF69Grt378bMmTONro/VPVXNA41r165h4cKFWLRoERQKhd6YoqIivdM05wqpqanaOAB6YxUKBU6fPg21Wg2gLKdsbW0xa9Ys/PDDD7h58yaOHDmCd999F4GBgQgNDTW6nYwBlnFepFFQUAAHBwfUq1cPTk5OmDRpEh4+fFju+jEzPuQnPT0dAFC/fn2MGDECJSUl2LFjhyCmuLgYO3fuxMCBAyGXy42qf/DgwSgsLMSCBQvQt29fxMXFYezYsaZqvsDt27cBlHVAn9SjRw/06NFD+76goADff/89unXrhiZNmuita8iQIZDJZNi3b5/OtNzcXGRnZ+Pu3bs4ffo0xowZA7lcjsGDB5twbZg+mZmZ8PT01CnXlN26davCeZ+MfXr+3Nxc7QlDZmYm3N3ddS4QPL0cc9fJLEdVt33N9mLIvJmZmZBIJHBzcxPESaVSODs7a+OMqdMYY8aMQXR0NDZt2oRWrVqhcePGiI6ORlxcHKZOnWp0fazueZZjAAC88847aN++PYYOHVpuTIsWLXDjxg1kZGQIyo8ePQqg7AQaAHx9fSESiXDs2DFB3Pnz55GVlQWVSoV79+4BKDsv2bFjB/Ly8tCjRw80bNgQL7/8Mry8vPDDDz/oXKA2pJ2MAZZxXqQpe/fdd7FhwwZs27YN/fv3x6pVq9CnTx+UlJSUu46WzqryENPIy8tDdnY2CgsLkZKSgjlz5kAmkyEsLAwNGzZEly5dsGXLFsHTyvbv34979+5hxIgRRi+vSZMm2Lt3LwBg0qRJcHBwwKpVqzBt2jS0bdvWZOtVXFyM5cuXo0mTJggMDKww9uLFiygpKUG7du3KjZHJZGjRogX++ecfnWktWrQQvHd0dMRXX32l91tVZloqlQoymUynXHPhQ6VSVTgvgErnl8lkBi/H3HUyy1HVbd/Q7Unzr1Qq1VuPXC43ehs1lkQigVKpRO/evREeHg65XI5t27Zh8uTJ8PDwwGuvvWZ0naxueZZjwI8//ohdu3YhJSWlwmW89dZbWL16NQYPHoxly5bB3d0dX3zxBfbs2SNYhouLCwYPHoxNmzbBz88Pr7/+Om7evInJkyfD2toajx8/FrTH1dUV7du3R3R0NPz9/XHmzBksXrwYo0aNEjyh1tB2MgZYxnkRACxYsEAQM3ToUDRv3hzvv/8+du7cyRdjylFtHcynb8No3LgxtmzZgoYNGwIARo4ciQkTJuDy5ctQKpUAgK1bt8Lb2xvdu3c3enmTJk0SvJ88eTJWrVqFAwcOmLSDGR0djX/++Qf79+/XuRKo+ZZWQ3Prlr29fYV12tvb673Na9euXXBwcAAR4ebNm0hISMDAgQNx8OBBdO3a9dlWhAEou2CQm5srKHN1dYVCodD77Z3mtuuKbiXSTDNkfkOXY+46meWo6rZv7DZaXFyst57CwsLnvo0uXLgQK1aswMWLF2FnZweg7C6YkJAQTJo0CWFhYTr7d2ZZqpoHJSUlmDJlCkaMGFHpRei2bdvi888/x/jx4/Hiiy8CKPspzPLlyzFhwgTttgkAiYmJUKlUmDZtGqZNmwYAiIiIgFKpxO7du7WxV65cQUhICDZv3oyBAwcCAAYMGKD9idC3336Lf/3rX0a1k1kWSz4vKs+///1vzJo1C4cPH+YOZjmq7RbZ+Ph4HDp0CDt37kTfvn2RnZ0tuHqguTV069atAMq+8fzmm28wfPjwKv2e0NfXV/BeqVRCLBbrdPqexZIlS7BmzRrMnTsXffv2rTRe07Gs7DdCDx480LlVDACCg4MRGhqKnj17IioqCt9//z3s7e0xefLkqq0A0/Hrr7/C09NT8Lp+/To8PT21t188SVPm5eVVbp2aWy7Km9/JyUmbC56enrh9+7bm4VrlLsfcdTLLUdVtX7O9GDKvp6cnSktLcffuXUFccXExcnJytHHG1GmMVatW4ZVXXhGcwANA//79cevWLZMeN1jtVNU82Lx5M86fP49x48YhPT1d+wLKjvXp6ekoKCjQxg8aNAi3bt3CiRMncPz4cWRkZKBp06YAgObNm2vj6tWrh7179yIjIwNHjhxBeno6kpOTkZmZCVdXVzg6OgIANm7ciMLCQoSFhQna1b9/fwDQ3mZrbDuZ5bDk86LyKBQKODs763S82f9UWwczKCgIoaGhGDhwIL7++mu0bt0aw4YN0/5Itn79+ggLC9N2MHfu3ImioiJERESYZPmmfujNxo0bERMTg/Hjx+ODDz4waB5fX19YWVnh7Nmz5cYUFRXh/Pnz2gNKRezs7NCpUyecOnUKjx49MrjtrHzt2rXDoUOHBC8PDw8EBATg1KlT2gcnaKSkpMDGxkZw4H9agwYN4OrqipMnT+pMO3HiBAICArTvAwICUFBQoPPAKM0tS5pYc9fJLEdAQAAuXLiA/Px8QfnT28/TxGIx2rRpo3d7SklJQdOmTbUX3TR1PB178uRJqNVq7XRj6jTGnTt3UFpaqlP++PFjAODf2bAq58G1a9fw+PFjvPjii2jSpIn2BZR16po0aYKDBw8K5pFKpQgMDETnzp0hlUpx+PBhALp3ggFAo0aNEBwcDB8fH9y/fx+pqamCuDt37oCIdLbvp7ftqrSTWQZLPi8qz4MHD5CdnQ1XV9cK4yxaRY+Ypec4TMmPP/5IAGjBggXasr1792rHNwsJCaH27dsbvTzNkB7//e9/BeVpaWk6y/Px8anSEB5fffUVSSQSGjhwoM7jmSvTu3dvkkgklJ6ernf65s2bdcaxKm+YEiLSDgx7+/ZtvfXxMCWmsX37dp1HvWdlZZGjoyMNGTJEEHvp0iW6dOmSoGz8+PGkUCgEj7I/fPiwdnxTjevXr5c7NlODBg0EYzOZs05LwTlA9Ntvv+mM/1dYWEjNmjWjTp06acsyMjIoLS1NMO/ChQt19v/nzp0jiURCMTEx2rKCggJycnKisLAwwfwRERFkY2MjGJ/S0DqfVtG+sHXr1uTk5ETZ2dnaspKSEurYsSPZ29sbNV5yXcR5UPU8SEtLoz179ui8AFDfvn1pz549dOvWrXKXe+HCBbK3t9fJDX3Gjx9PYrFYMEbsJ598QgBow4YNgtjly5cTANq+fbtJ2mkJOA+ELOG8SKVSUX5+vs66T58+vdxxZOu6Gj8OJhFRUFAQubu7k0qlIiKi4uJicnFxoYEDB5JYLKZPP/3U6OVpOmP9+/cXlE+cOJEA0JkzZ7RlVelgHjlyhORyOYWEhFQ6xo++hDp69CiJxWJ6+eWXqaCgQDDtypUr5OHhQd7e3gaNg5mTk0P169cnDw8PwWDLT+IOpmmUlJRQ586dyc7OjubMmUPx8fHk7+9P9vb2dO7cOUGsj48P+fj4CMquXbtGzs7OpFQqKS4ujubPn0/169enNm3a6GxHmh3X2LFjac2aNdqLCFu3bq1RdVoCzoEy4eHhZGVlRdOnT6fExETq2rUrWVlZ0ZEjR7Qx3bt3p7Jrlv+Tn59PSqWS3NzcaPHixbRs2TLy9vYmLy8vunv3riBWMy7ZoEGDaM2aNTRy5EgCQB9//HGV6/z6669p7ty5NHfuXJJKpdS+fXvt+z/++EMbp/mclUolLVq0iOLi4qhLly4EgObNm2eqP2OtxXlQpqp5oA/KGV/Sz8+PPvzwQ1q7di29//775OTkRD4+PnTjxg1B3IIFC2j48OEUFxdHq1atol69eundXrOzs8nDw4OkUilNmTKFEhMTady4cSSRSMjf35+Kioqq1E5LxHkgZAnnRVevXiVHR0eaMGECrVixglasWEF9+/YlANSnTx+jv2SqC2pFB/PLL7/UuaoQHR1NAEgikVTpapmmM9amTRt69dVXKT4+niIiIggADRs2TBBrbAczPT2d6tWrRwqFguLj4yk5OVnwevKERVP/0wlFRLRixQoSiUTUrFkzmjdvHq1bt46mT59Ojo6O5OTkRL/99pvedUpISKDk5GTavHkzLVy4kHx9fQkArV69WhBv6ElVZXhnKpSbm0ujR48mZ2dnsrGxoe7du+vdrsv73P/66y/q1asX2djYkKOjIw0fPlzvN8+lpaU0f/588vHxIalUSv7+/rRlyxa9bTJnnZaAc6CMSqWiadOmkYeHB8lkMgoMDKTvvvtOEFPeifX169dp0KBB5ODgQHZ2dhQWFkYXL17Uu5ykpCRq0aIFSaVSUiqVtGzZMr0XzwytMzIyUnMg1Hk9/Y3Od999R927dycXFxeSSqXUpk0bnX2rpeI8KPMsefC08jpuQ4cOJW9vb5JKpeTl5UXjx4+nO3fu6MR98803FBQURPb29mRjY0OdO3emL774Qu+ybty4QW+++SY1adKEpFIpeXp60pgxY/TeFWVoOy0R54Guun5edO/ePYqIiKBmzZqRjY0NyWQy8vf3p/nz51vsnS21ooNZWlpKSqWSlEql9uvoEydOEADq1auX0csi+l9n7J9//qFBgwaRvb091a9fn6Kjo7XflGoY28HU3NZb3is2Nlanfn0JRVT2TeaAAQPIxcWFRCIRASA3NzfKzMwsd52efNna2lKXLl30HlCMOamqCO9MmaXjHGCM84AxIs4DxogM72A+9+euR0VFISoqSu80sViMS5cuCco0Y6E968N9XF1dBeM76WPskwFffvllnSdOVbX+l156CS+99JL2/dy5c/Hhhx9i5cqVmDdvniB29uzZmD17tsHL3bhxIzZu3GhwPGOMMcYYY4yZQo0b2GvNmjWws7PD//3f/5m7KdVq1qxZuHXrFj7++GM0atQIY8eONXeTGGOMMcYYY8woNaaDuW/fPvzzzz9ISkpCdHQ0bG1tBdMfPnyoHdKkPM/yuODbt29XOF2hUKBevXpVrt8QCQkJSEhIeK7LYIwxxhhjjLHnpcZ0MCdPnow7d+6gb9++mDNnjs70Tz75RG/5k65evVrl5WsGaC1PZGQk33bKGGOMMcYYYxWoMR3Myn4POXLkSMFvFvXx8PAw+veKGocOHapwupeXl9F1MsYYY4wxxpglqTEdzMo0bdoUTZs2fW71h4aGPre6GWOMMcYYY8wSGNXBTEtLe17tYDWQ5pZj/tyZpeIcYIzzgDGA84AxwPDtX2TIsBsikaiRWCw+r1ar5c/aMFa7iMViqNVqczeDMbPhHGCM84AxgPOAMQAQi8WFarW6BRFdKy/GoA4mUNbJBOBiqsaxWkMKoNjcjWDMjDgHGOM8YAzgPGAMALIr6lwCRnQwGWOMMcYYY4yxiojN3QDGGGOMMcYYY3UDdzAZY4wxxhhjjJkEdzAZY4wxxhhjjJkEdzAZY4wxxhhjjJkEdzAZY4wxxhhjjJkEdzAZY4wxxhhjjJkEdzAZY4wxxhhjjJnE/wO7dj8aIw2yxwAAAABJRU5ErkJggg=="
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 10
   },
   {
    "cell_type": "markdown",

--- a/src/iqm/benchmarks/compressive_gst/gst_analysis.py
+++ b/src/iqm/benchmarks/compressive_gst/gst_analysis.py
@@ -316,9 +316,7 @@ def generate_unit_rank_gate_results(
         bootstrap_pauli_coeffs = np.zeros((len(X_array), dataset.attrs["num_gates"], dataset.attrs["pdim"] ** 2))
         for i, X_ in enumerate(X_array):
             X_std, _, _ = compatibility.pp2std(X_, E_array[i], rho_array[i])
-            U_opt_ = reporting.phase_opt(
-                np.array([change_basis(X_std[j], "pp", "std") for j in range(dataset.attrs["num_gates"])]), K_target
-            )
+            U_opt_ = reporting.phase_opt(X_std, K_target)
             pauli_coeffs_ = reporting.compute_sparsest_Pauli_Hamiltonian(U_opt_)
             bootstrap_pauli_coeffs[i, :, :] = pauli_coeffs_
         pauli_coeffs_low, pauli_coeffs_high = np.nanpercentile(bootstrap_pauli_coeffs, [2.5, 97.5], axis=0)

--- a/src/mGST/algorithm.py
+++ b/src/mGST/algorithm.py
@@ -719,7 +719,7 @@ def run_mGST(
         for _ in trange(final_iter):
             K, X, E, rho, A, B = optimize(y, J, d, r, rK, n_povm, method, K, rho, A, B, fixed_elements)
             res_list.append(objf(X, E, rho, J, y))
-            if np.abs(res_list[-2] - res_list[-1]) < delta * target_rel_prec:
+            if len(res_list) >= 2 and np.abs(res_list[-2] - res_list[-1]) < delta * target_rel_prec:
                 break
     if testing:
         plot_objf(res_list, delta, f"Objective function over batches and full data")

--- a/src/mGST/algorithm.py
+++ b/src/mGST/algorithm.py
@@ -711,7 +711,7 @@ def run_mGST(
                 plot_objf(res_list, delta, f"Objective function for batch optimization")
             if success:
                 break
-            qcvv_logger.info(f"Run {i} failed, trying new initialization...")
+            qcvv_logger.info(f"Run {i+1}/{max_inits} failed, trying new initialization...")
 
     if not success and max_inits > 0:
         qcvv_logger.info(f"Success threshold not reached, attempting optimization over full data set...")

--- a/src/mGST/algorithm.py
+++ b/src/mGST/algorithm.py
@@ -711,7 +711,7 @@ def run_mGST(
             plot_objf(res_list, delta, f"Objective function for batch optimization")
         if success:
             break
-        qcvv_logger.info(f"Run ", i, f"failed, trying new initialization...")
+        qcvv_logger.info(f"Run {i} failed, trying new initialization...")
 
     if not success and max_inits > 0:
         qcvv_logger.info(f"Success threshold not reached, attempting optimization over full data set...")


### PR DESCRIPTION
- Fixed a bug that led to bootstrapping analysis being performed in the wrong basis
- Fixed a logging message that was displayed incorrectly
- Fixed an issue where random initializations were not redrawn when setting `from_init = False`
- Updated Jupyter notebook for GST with more default circuits for 2 qubit GST, and a brief description on how to get a unitary model from the same benchmark run. 